### PR TITLE
Add payload validation for devmem TCP

### DIFF
--- a/devmem.c
+++ b/devmem.c
@@ -651,7 +651,8 @@ static int devmem_handle_token(int fd, struct connection_devmem *conn,
 
 ssize_t devmem_recv(int fd, struct connection_devmem *conn,
 		    unsigned char *rxbuf, size_t chunk,
-		    struct memory_buffer *mem, int rep, __u64 tot_recv)
+		    struct memory_buffer *mem, int rep, __u64 tot_recv,
+		    bool validate)
 {
 	struct msghdr msg = {};
 	struct iovec iov = {
@@ -680,9 +681,12 @@ ssize_t devmem_recv(int fd, struct connection_devmem *conn,
 		if (ret < 0)
 			return ret;
 
-		ret = devmem_validate_token(mem, cm, rep, &tot_recv);
-		if (ret < 0)
-			return ret;
+		if (validate) {
+			ret = devmem_validate_token(mem, cm, rep, &tot_recv);
+			if (ret < 0)
+				return ret;
+		}
+
 	}
 
 	return n;

--- a/proto.c
+++ b/proto.c
@@ -181,7 +181,7 @@ int kpm_send_tcp_cc(int fd, __u32 id, char *cc_name)
 }
 
 int kpm_send_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-		  __u32 udmabuf_size_mb, __u32 num_rx_queues)
+		  __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate)
 {
 	struct kpm_mode msg = {};
 
@@ -189,6 +189,7 @@ int kpm_send_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
 	msg.tx_mode = tx_mode;
 	msg.udmabuf_size_mb = udmabuf_size_mb;
 	msg.num_rx_queues = num_rx_queues;
+	msg.validate = validate;
 
 	return kpm_send(fd, &msg.hdr, sizeof(msg), KPM_MSG_TYPE_MODE);
 }
@@ -458,12 +459,12 @@ kpm_req_tcp_cc(int fd, __u32 conn_id, char *cc_name)
 
 int
 kpm_req_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-	     __u32 udmabuf_size_mb, __u32 num_rx_queues)
+	     __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate)
 {
 	struct kpm_empty *repl;
 	int id;
 
-	id = kpm_send_mode(fd, rx_mode, tx_mode, udmabuf_size_mb, num_rx_queues);
+	id = kpm_send_mode(fd, rx_mode, tx_mode, udmabuf_size_mb, num_rx_queues, validate);
 	if (id < 0) {
 		warnx("Failed to request mode");
 		return id;

--- a/proto.h
+++ b/proto.h
@@ -139,6 +139,7 @@ struct kpm_mode {
 	enum kpm_tx_mode tx_mode;
 	__u32 udmabuf_size_mb;
 	__u32 num_rx_queues;
+	__u8 validate;
 };
 
 enum kpm_tls_mask {
@@ -273,7 +274,7 @@ int kpm_send_tls(int fd, __u32 conn_id, __u32 dir_mask,
 int kpm_send_max_pacing(int fd, __u32 id, __u32 max_pace);
 int kpm_send_tcp_cc(int fd, __u32 id, char *cc_name);
 int kpm_send_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-		  __u32 udmabuf_size_mb, __u32 num_rx_queues);
+		  __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate);
 int kpm_send_pin_worker(int fd, __u32 id, __u32 cpu);
 
 void kpm_reply_error(int fd, struct kpm_header *hdr, __u16 error);
@@ -297,7 +298,7 @@ int kpm_req_tls(int fd, __u32 conn_id, __u32 dir_mask,
 int kpm_req_pacing(int fd, __u32 conn_id, __u32 max_pace);
 int kpm_req_tcp_cc(int fd, __u32 conn_id, char *cc_name);
 int kpm_req_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-		 __u32 udmabuf_size_mb, __u32 num_rx_queues);
+		 __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate);
 int kpm_req_disconnect(int fd, __u32 connection_id);
 
 #endif /* PROTO_H */

--- a/server.h
+++ b/server.h
@@ -75,7 +75,7 @@ struct server_session *
 server_session_spawn(int fd, struct sockaddr_in6 *addr, socklen_t *addrlen);
 
 void NORETURN pworker_main(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-                           struct memory_buffer *devmem);
+                           struct memory_buffer *devmem, bool validate);
 
 int devmem_setup(struct session_state_devmem *devmem, int fd,
 		 size_t udmabuf_size, int num_queues);
@@ -83,6 +83,6 @@ int devmem_teardown(struct session_state_devmem *devmem);
 int devmem_release_tokens(int fd, struct connection_devmem *conn);
 ssize_t devmem_recv(int fd, struct connection_devmem *conn,
 		    unsigned char *rxbuf, size_t chunk, struct memory_buffer *mem,
-		    int rep, __u64 tot_recv);
+		    int rep, __u64 tot_recv, bool validate);
 
 #endif /* SERVER_H */

--- a/server_session.c
+++ b/server_session.c
@@ -42,6 +42,7 @@ struct session_state {
 	struct list_head pworkers;
 	struct list_head tests;
 	struct session_state_devmem devmem;
+	bool validate;
 };
 
 struct connection {
@@ -522,6 +523,7 @@ server_msg_mode(struct session_state *self, struct kpm_header *hdr)
 
 	self->rx_mode = req->rx_mode;
 	self->tx_mode = req->tx_mode;
+	self->validate = req->validate;
 
 	if (kpm_reply_empty(self->main_sock, hdr) < 1) {
 		warnx("Reply failed");
@@ -558,7 +560,8 @@ server_msg_spawn_pworker(struct session_state *self, struct kpm_header *hdr)
 	}
 	if (!pwrk->pid) {
 		close(p[0]);
-		pworker_main(p[1], self->rx_mode, self->tx_mode, &self->devmem.mem);
+		pworker_main(p[1], self->rx_mode, self->tx_mode, &self->devmem.mem,
+			     self->validate);
 		exit(1);
 	}
 


### PR DESCRIPTION
Make the following changes:
- support payload validation for devmem TCP
- make payload validation optional for all tests types
- disable payload validation by default
- refactor udmabuf info to allow easier passing between setup context (server session) and receive context (pworker) for payload validation

Payload validation is made optional because it reduces kperf throughput for devmem TCP by ~90% and this is probably not desired for all tests. It is disabled by default for even non-devmem tests to simplify usage (avoid users needing to know the performance caveat for devmem).

Upon failure, the server output is the following:
```
server: Data corruption -105 -106 2560 149 560384 6
server: Recv failed: Invalid argument
server: Data corruption 72 72 3584 71 597536 4
server: Recv failed: Invalid argument
server: Failed to receive header (-1): Connection reset by peer
```

Upon success, the server output is the same as before:

```
TCP stats
         1 0 0 0 0 7 11 11 1 0
         201000 40000 4128 4128 0 0 0 0 0
Times:   5145 0 1 1
Metrics: 4200 8429611 71 36 2147483647 10 4128 12
rcv_rtt| 266 2852640 0
pacing_| 1148660869 18446744073709551615 16 8968192472
segs_ou| 51507 2195771 0 43 2195768 1
de-ry_r| 96000000 0 0 0
de-ered| 2 0
bytes_s| 16 0
dsack_d| 0 0 0 63488TCP stats
         1 0 0 0 0 7 11 11 1 0
         201000 40000 4128 4128 0 0 0 0 0
Times:   5144 0 1 1
Metrics: 4200 27449591 68 38 2147483647 10 4128 12
rcv_rtt| 918 5651584 0
pacing_| 1203060109 18446744073709551615 16 9041444228
segs_ou| 21130 2209236 0 17 2209233 1
de-ry_r| 242823529 0 0 0
de-ered| 2 0
bytes_s| 16 0
dsack_d| 0 0 0 63488
```

See commits for more details.