### PR TITLE
server: close conn->fd so that worker close() is final

### DIFF
--- a/server_session.c
+++ b/server_session.c
@@ -731,6 +731,8 @@ bad_req:
 		for (j = 0; j < msg->n_conns; j++) {
 			conn = session_find_connection_by_id(self, msg->specs[j].connection_id);
 			fdpass_send(pwrk->fd, conn->fd);
+			/* close to ensure the only open descriptors are owned by the worker. */
+			close(conn->fd);
 		}
 	}
 


### PR DESCRIPTION
This descriptor staying open on the server side can cause epoll_wait() in the worker to propagate events even after the worker has closed the socket and free'd the connection. When passing the fd from epoll events to worker_find_connection_by_fd(), NULL can be returned. Presumptuous callers segfault on the null ptr.