### PR TITLE
Devmem cuda tx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,18 @@ CFLAGS += -I$(YNL_PATH)/include/
 LIBS=-lm -L$(CCAN_PATH) -pthread -lccan
 LIBS += -L$(YNL_PATH) -lynl
 
+ifdef USE_CUDA
+    CFLAGS += -I/usr/local/cuda/include/ -DUSE_CUDA
+endif
+
 include $(wildcard *.d)
 
 all: server client units
 units: bipartite_match cpu_stat
+
+ifdef USE_CUDA
+server: LIBS += -lcuda -lcudart -L/usr/local/cuda/lib64
+endif
 
 server: $(CCAN_PATH)/libccan.a $(YNL_PATH)/libynl.a server.o server_session.o proto.o worker.o devmem.o cpu_stat.o tcp.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)

--- a/client.c
+++ b/client.c
@@ -25,6 +25,8 @@ static struct {
 	bool msg_trunc;
 	bool devmem_rx;
 	char *devmem_rx_memory;
+	char *devmem_tx_memory;
+	char *devmem_src_dev;
 	char *devmem_dst_dev;
 	bool devmem_tx;
 	bool msg_zerocopy;
@@ -77,6 +79,8 @@ static struct {
 	.udmabuf_size_mb = 128,
 	.num_rx_queues = 1,
 	.devmem_rx_memory = "host",
+	.devmem_tx_memory = "host",
+	.devmem_src_dev = "any",
 	.devmem_dst_dev = "any",
 };
 
@@ -161,12 +165,16 @@ static const struct opt_table opts[] = {
 	OPT_WITH_ARG("--devmem-rx-memory {cuda,host}", opt_set_charp, opt_show_charp,
 		     &opt.devmem_rx_memory, "Select the memory provider for TCP Devmem RX"),
 	OPT_WITHOUT_ARG("--devmem-tx", opt_set_bool, &opt.devmem_tx, "Use TCP Devmem on transmit"),
+	OPT_WITH_ARG("--devmem-tx-memory {cuda,host}", opt_set_charp, opt_show_charp,
+		     &opt.devmem_tx_memory, "Select the memory provider for TCP Devmem TX"),
 	OPT_WITH_ARG("--udmabuf-size-mb <arg>", opt_set_uintval, opt_show_uintval,
 		     &opt.udmabuf_size_mb, "Size of RX udmabuf for TCP Devmem mode"),
 	OPT_WITH_ARG("--num-rx-queues <arg>", opt_set_uintval, opt_show_uintval,
 		     &opt.num_rx_queues, "Number of RX queues for TCP Devmem mode"),
 	OPT_WITH_ARG("--validate <yes|no>", opt_set_bool_arg, NULL, &opt.validate,
 		     "Validate payload. Default is no when using --devmem-rx; otherwise, default is yes"),
+	OPT_WITH_ARG("--devmem-src-dev <arg>", opt_set_charp, opt_show_charp,
+		     &opt.devmem_src_dev, "Select the source device for the TCP Devmem memory provider"),
 	OPT_WITH_ARG("--devmem-dst-dev <arg>", opt_set_charp, opt_show_charp,
 		     &opt.devmem_dst_dev, "Select the destination device for the TCP Devmem memory provider"),
 	OPT_ENDTABLE
@@ -562,7 +570,7 @@ dump_result_machine(struct kpm_test_results *result, const char *dir,
 
 int main(int argc, char *argv[])
 {
-	enum memory_provider_type rx_provider;
+	enum memory_provider_type rx_provider, tx_provider;
 	enum kpm_rx_mode rx_mode = KPM_RX_MODE_SOCKET;
 	enum kpm_tx_mode tx_mode = KPM_TX_MODE_SOCKET;
 	unsigned int src_ncpus, dst_ncpus;
@@ -576,6 +584,7 @@ int main(int argc, char *argv[])
 	struct addrinfo *addr;
 	struct kpm_test *test;
 	struct pci_dev dst_dev;
+	struct pci_dev src_dev;
 	unsigned int i;
 	socklen_t len;
 	int src, dst;
@@ -658,6 +667,19 @@ int main(int argc, char *argv[])
 	else if (opt.devmem_rx)
 		rx_mode = KPM_RX_MODE_DEVMEM;
 
+	if (opt.msg_zerocopy && opt.devmem_tx)
+		errx(1, "--msg-zerocopy and --devmem-tx are mutually exclusive");
+
+	if (!strcmp(opt.devmem_tx_memory, "host")) {
+		tx_provider = MEMORY_PROVIDER_HOST;
+	} else if (!strcmp(opt.devmem_tx_memory, "cuda")) {
+		if (!use_cuda)
+			errx(1, "--devmem-tx-memory cuda selected, but kperf not compiled with CUDA support");
+		tx_provider = MEMORY_PROVIDER_CUDA;
+	} else {
+		errx(1, "--devmem-tx-memory arg invalid: %s", opt.devmem_tx_memory);
+	}
+
 	if (!strcmp(opt.devmem_rx_memory, "host")) {
 		rx_provider = MEMORY_PROVIDER_HOST;
 	} else if (!strcmp(opt.devmem_rx_memory, "cuda")) {
@@ -687,20 +709,30 @@ int main(int argc, char *argv[])
 		dst_dev.device = DEVICE_DEVICE_ANY;
 	} else if (sscanf(opt.devmem_dst_dev, "%hx:%hhx:%hhx", &dst_dev.domain,
 			  &dst_dev.bus, &dst_dev.device) != 3) {
+		errx(1, "--devmem-src-dev invalid PCI ID format. Expected format: domain:bus:device\n");
+		return -1;
+	}
+
+	if (!strcmp(opt.devmem_src_dev, "any")) {
+		src_dev.domain = DEVICE_DOMAIN_ANY;
+		src_dev.bus = DEVICE_BUS_ANY;
+		src_dev.device = DEVICE_DEVICE_ANY;
+	} else if (sscanf(opt.devmem_src_dev, "%hx:%hhx:%hhx", &src_dev.domain,
+			  &src_dev.bus, &src_dev.device) != 3) {
 		errx(1, "--devmem-dst-dev invalid PCI ID format. Expected format: domain:bus:device\n");
 		return -1;
 	}
 
 	if (kpm_req_mode(dst, rx_mode, tx_mode, opt.udmabuf_size_mb,
 			 opt.num_rx_queues, opt.validate,
-			 rx_provider, &dst_dev) < 0) {
+			 rx_provider, tx_provider, &dst_dev) < 0) {
 		warnx("Failed setup destination mode");
 		goto out;
 	}
 
 	if (kpm_req_mode(src, rx_mode, tx_mode, opt.udmabuf_size_mb,
 			 opt.num_rx_queues, opt.validate,
-			 rx_provider, &dst_dev) < 0) {
+			 rx_provider, tx_provider, &src_dev) < 0) {
 		warnx("Failed setup source mode");
 		goto out;
 	}

--- a/client.c
+++ b/client.c
@@ -26,6 +26,7 @@ static struct {
 	bool devmem_rx;
 	char *devmem_rx_memory;
 	char *devmem_dst_dev;
+	bool devmem_tx;
 	bool msg_zerocopy;
 	bool tls;
 	bool tls_rx;
@@ -159,6 +160,7 @@ static const struct opt_table opts[] = {
 	OPT_EARLY_WITHOUT_ARG("--devmem-rx", opt_set_bool, &opt.devmem_rx, "Use TCP Devmem on receive"),
 	OPT_WITH_ARG("--devmem-rx-memory {cuda,host}", opt_set_charp, opt_show_charp,
 		     &opt.devmem_rx_memory, "Select the memory provider for TCP Devmem RX"),
+	OPT_WITHOUT_ARG("--devmem-tx", opt_set_bool, &opt.devmem_tx, "Use TCP Devmem on transmit"),
 	OPT_WITH_ARG("--udmabuf-size-mb <arg>", opt_set_uintval, opt_show_uintval,
 		     &opt.udmabuf_size_mb, "Size of RX udmabuf for TCP Devmem mode"),
 	OPT_WITH_ARG("--num-rx-queues <arg>", opt_set_uintval, opt_show_uintval,
@@ -656,7 +658,6 @@ int main(int argc, char *argv[])
 	else if (opt.devmem_rx)
 		rx_mode = KPM_RX_MODE_DEVMEM;
 
-
 	if (!strcmp(opt.devmem_rx_memory, "host")) {
 		rx_provider = MEMORY_PROVIDER_HOST;
 	} else if (!strcmp(opt.devmem_rx_memory, "cuda")) {
@@ -672,8 +673,13 @@ int main(int argc, char *argv[])
 		errx(1, "--devmem-rx-memory arg invalid: %s", opt.devmem_rx_memory);
 	}
 
+	if (opt.msg_zerocopy && opt.devmem_tx)
+		errx(1, "--msg-zerocopy and --devmem-tx are mutually exclusive");
+
 	if (opt.msg_zerocopy)
 		tx_mode = KPM_TX_MODE_SOCKET_ZEROCOPY;
+	else if (opt.devmem_tx)
+		tx_mode = KPM_TX_MODE_DEVMEM;
 
 	if (!strcmp(opt.devmem_dst_dev, "any")) {
 		dst_dev.domain = DEVICE_DOMAIN_ANY;

--- a/client.c
+++ b/client.c
@@ -24,6 +24,8 @@ int verbose = 3;
 static struct {
 	bool msg_trunc;
 	bool devmem_rx;
+	char *devmem_rx_memory;
+	char *devmem_dst_dev;
 	bool msg_zerocopy;
 	bool tls;
 	bool tls_rx;
@@ -73,9 +75,17 @@ static struct {
 	/* 128M is enough to drive one queue at 200G */
 	.udmabuf_size_mb = 128,
 	.num_rx_queues = 1,
+	.devmem_rx_memory = "host",
+	.devmem_dst_dev = "any",
 };
 
 #define dbg(fmt...) while (0) { warnx(fmt); }
+
+#ifdef USE_CUDA
+static bool use_cuda = true;
+#else
+static bool use_cuda = false;
+#endif
 
 static void opt_show_uinthex(char buf[OPT_SHOW_LEN], const unsigned int *ui)
 {
@@ -147,12 +157,16 @@ static const struct opt_table opts[] = {
 	OPT_WITHOUT_ARG("--msg-trunc", opt_set_bool, &opt.msg_trunc, "Use MSG_TRUNC on receive"),
 	OPT_WITHOUT_ARG("--msg-zerocopy", opt_set_bool, &opt.msg_zerocopy, "Use MSG_ZEROCOPY on transmit"),
 	OPT_EARLY_WITHOUT_ARG("--devmem-rx", opt_set_bool, &opt.devmem_rx, "Use TCP Devmem on receive"),
+	OPT_WITH_ARG("--devmem-rx-memory {cuda,host}", opt_set_charp, opt_show_charp,
+		     &opt.devmem_rx_memory, "Select the memory provider for TCP Devmem RX"),
 	OPT_WITH_ARG("--udmabuf-size-mb <arg>", opt_set_uintval, opt_show_uintval,
 		     &opt.udmabuf_size_mb, "Size of RX udmabuf for TCP Devmem mode"),
 	OPT_WITH_ARG("--num-rx-queues <arg>", opt_set_uintval, opt_show_uintval,
 		     &opt.num_rx_queues, "Number of RX queues for TCP Devmem mode"),
 	OPT_WITH_ARG("--validate <yes|no>", opt_set_bool_arg, NULL, &opt.validate,
 		     "Validate payload. Default is no when using --devmem-rx; otherwise, default is yes"),
+	OPT_WITH_ARG("--devmem-dst-dev <arg>", opt_set_charp, opt_show_charp,
+		     &opt.devmem_dst_dev, "Select the destination device for the TCP Devmem memory provider"),
 	OPT_ENDTABLE
 };
 
@@ -546,6 +560,7 @@ dump_result_machine(struct kpm_test_results *result, const char *dir,
 
 int main(int argc, char *argv[])
 {
+	enum memory_provider_type rx_provider;
 	enum kpm_rx_mode rx_mode = KPM_RX_MODE_SOCKET;
 	enum kpm_tx_mode tx_mode = KPM_TX_MODE_SOCKET;
 	unsigned int src_ncpus, dst_ncpus;
@@ -558,6 +573,7 @@ int main(int argc, char *argv[])
 	__u32 src_tst_id, dst_tst_id;
 	struct addrinfo *addr;
 	struct kpm_test *test;
+	struct pci_dev dst_dev;
 	unsigned int i;
 	socklen_t len;
 	int src, dst;
@@ -640,17 +656,45 @@ int main(int argc, char *argv[])
 	else if (opt.devmem_rx)
 		rx_mode = KPM_RX_MODE_DEVMEM;
 
+
+	if (!strcmp(opt.devmem_rx_memory, "host")) {
+		rx_provider = MEMORY_PROVIDER_HOST;
+	} else if (!strcmp(opt.devmem_rx_memory, "cuda")) {
+		if (!use_cuda)
+			errx(1, "--devmem-rx-memory cuda selected, but kperf not compiled with CUDA support");
+
+		/* TODO: support --validate yes for cuda rx */
+		if (opt.validate)
+			errx(1, "--devmem-rx-memory cuda does not support --validate yes");
+
+		rx_provider = MEMORY_PROVIDER_CUDA;
+	} else {
+		errx(1, "--devmem-rx-memory arg invalid: %s", opt.devmem_rx_memory);
+	}
+
 	if (opt.msg_zerocopy)
 		tx_mode = KPM_TX_MODE_SOCKET_ZEROCOPY;
 
+	if (!strcmp(opt.devmem_dst_dev, "any")) {
+		dst_dev.domain = DEVICE_DOMAIN_ANY;
+		dst_dev.bus = DEVICE_BUS_ANY;
+		dst_dev.device = DEVICE_DEVICE_ANY;
+	} else if (sscanf(opt.devmem_dst_dev, "%hx:%hhx:%hhx", &dst_dev.domain,
+			  &dst_dev.bus, &dst_dev.device) != 3) {
+		errx(1, "--devmem-dst-dev invalid PCI ID format. Expected format: domain:bus:device\n");
+		return -1;
+	}
+
 	if (kpm_req_mode(dst, rx_mode, tx_mode, opt.udmabuf_size_mb,
-			 opt.num_rx_queues, opt.validate) < 0) {
+			 opt.num_rx_queues, opt.validate,
+			 rx_provider, &dst_dev) < 0) {
 		warnx("Failed setup destination mode");
 		goto out;
 	}
 
-	if (kpm_req_mode(src, rx_mode, tx_mode, opt.udmabuf_size_mb, opt.num_rx_queues,
-			 opt.validate) < 0) {
+	if (kpm_req_mode(src, rx_mode, tx_mode, opt.udmabuf_size_mb,
+			 opt.num_rx_queues, opt.validate,
+			 rx_provider, &dst_dev) < 0) {
 		warnx("Failed setup source mode");
 		goto out;
 	}

--- a/devmem.c
+++ b/devmem.c
@@ -315,7 +315,7 @@ static int udmabuf_check_size(size_t size_mb)
 	return ret;
 }
 
-static int udmabuf_alloc(struct session_state_devmem *devmem, size_t size_mb)
+static int udmabuf_alloc(struct memory_buffer *mem, const char *name, size_t size_mb)
 {
 	struct udmabuf_create create;
 	int ret;
@@ -324,23 +324,23 @@ static int udmabuf_alloc(struct session_state_devmem *devmem, size_t size_mb)
 	if (ret < 0)
 		return ret;
 
-	devmem->udmabuf_devfd = open("/dev/udmabuf", O_RDWR);
-	if (devmem->udmabuf_devfd < 0)
+	mem->devfd = open("/dev/udmabuf", O_RDWR);
+	if (mem->devfd < 0)
 		return -errno;
 
-	devmem->udmabuf_memfd = memfd_create("udmabuf-test", MFD_ALLOW_SEALING);
-	if (devmem->udmabuf_memfd < 0) {
+	mem->memfd = memfd_create(name, MFD_ALLOW_SEALING);
+	if (mem->memfd < 0) {
 		ret = -errno;
 		goto close_devfd;
 	}
 
-	ret = fcntl(devmem->udmabuf_memfd, F_ADD_SEALS, F_SEAL_SHRINK);
+	ret = fcntl(mem->memfd, F_ADD_SEALS, F_SEAL_SHRINK);
 	if (ret < 0) {
 		ret = -errno;
 		goto close_memfd;
 	}
 
-	ret = ftruncate(devmem->udmabuf_memfd, size_mb * 1024 * 1024);
+	ret = ftruncate(mem->memfd, size_mb * 1024 * 1024);
 	if (ret < 0) {
 		ret = -errno;
 		goto close_memfd;
@@ -348,48 +348,47 @@ static int udmabuf_alloc(struct session_state_devmem *devmem, size_t size_mb)
 
 	memset(&create, 0, sizeof(create));
 
-	create.memfd = devmem->udmabuf_memfd;
+	create.memfd = mem->memfd;
 	create.offset = 0;
 	create.size = size_mb * 1024 * 1024;
 
-        devmem->mem.fd = ioctl(devmem->udmabuf_devfd, UDMABUF_CREATE,
-				  &create);
-        if (devmem->mem.fd < 0) {
+        mem->fd = ioctl(mem->devfd, UDMABUF_CREATE, &create);
+        if (mem->fd < 0) {
 		ret = -errno;
 		goto close_memfd;
 	}
 
-	devmem->mem.size = size_mb * 1024 * 1024;
-	devmem->mem.buf_mem = mmap(NULL, devmem->mem.size, PROT_READ | PROT_WRITE,
-				  MAP_SHARED, devmem->mem.fd, 0);
+	mem->size = size_mb * 1024 * 1024;
+	mem->buf_mem = mmap(NULL, mem->size, PROT_READ | PROT_WRITE,
+				  MAP_SHARED, mem->fd, 0);
 
-	if (devmem->mem.buf_mem == MAP_FAILED) {
+	if (mem->buf_mem == MAP_FAILED) {
 		ret = -errno;
 		goto close_dmabuf_fd;
 	}
 
-	devmem->udmabuf_valid = true;
+	mem->valid = true;
 
 	return 0;
 
 close_dmabuf_fd:
-	close(devmem->mem.fd);
+	close(mem->fd);
 close_memfd:
-	close(devmem->udmabuf_memfd);
+	close(mem->memfd);
 close_devfd:
-	close(devmem->udmabuf_devfd);
+	close(mem->devfd);
 
 	return ret;
 }
 
-static void udmabuf_free(struct session_state_devmem *devmem)
+static void udmabuf_free(struct memory_buffer *mem)
 {
-	if (devmem->udmabuf_valid) {
-		close(devmem->mem.fd);
-		close(devmem->udmabuf_memfd);
-		close(devmem->udmabuf_devfd);
-		munmap(devmem->mem.buf_mem, devmem->mem.size);
-		devmem->udmabuf_valid = false;
+	if (mem->valid) {
+		close(mem->fd);
+		close(mem->memfd);
+		close(mem->devfd);
+		munmap(mem->buf_mem, mem->size);
+		mem->valid = false;
 	}
 }
 
@@ -480,7 +479,7 @@ int devmem_setup(struct session_state_devmem *devmem, int fd,
 		goto sock_destroy;
 	}
 
-	ret = udmabuf_alloc(devmem, udmabuf_size_mb);
+	ret = udmabuf_alloc(&devmem->mem, "udmabuf-test-rx", udmabuf_size_mb);
 	if (ret < 0) {
 		warnx("Failed to allocate udmabuf: %s", strerror(-ret));
 		ret = -1;
@@ -525,9 +524,9 @@ int devmem_setup(struct session_state_devmem *devmem, int fd,
 		queues[i].id = max_kernel_queue + i;
 	}
 
-        devmem->dmabuf_id = bind_rx_queue(ifindex, devmem->mem.fd, queues,
+        devmem->mem.dmabuf_id = bind_rx_queue(ifindex, devmem->mem.fd, queues,
                                           num_queues, devmem->ys);
-        if (devmem->dmabuf_id < 0) {
+        if (devmem->mem.dmabuf_id < 0) {
 		warnx("Failed to bind RX queue");
 		ret = -1;
 		goto free_queues;
@@ -542,7 +541,7 @@ undo_rss_context:
 undo_rss:
 	rss_equal(ifname, rxqn);
 free_udmabuf:
-	udmabuf_free(devmem);
+	udmabuf_free(&devmem->mem);
 sock_destroy:
 	ynl_sock_destroy(devmem->ys);
 	devmem->ys = NULL;
@@ -565,7 +564,7 @@ int devmem_teardown(struct session_state_devmem *devmem)
 	}
 	if (devmem->ys)
 		ynl_sock_destroy(devmem->ys);
-	udmabuf_free(devmem);
+	udmabuf_free(&devmem->mem);
 	return 0;
 }
 

--- a/devmem.c
+++ b/devmem.c
@@ -29,7 +29,22 @@
 
 #include "server.h"
 
+#ifdef USE_CUDA
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#ifdef CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE
+#define CUDA_FLAGS CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE
+#else
+#define CUDA_FLAGS 0
+#endif
+#endif
+
+#define ROUND_UP(n, d) ((((n) + (d) - 1) / (d)) * (d))
+
 extern unsigned char patbuf[KPM_MAX_OP_CHUNK + PATTERN_PERIOD + 1];
+
+extern int verbose;
 
 static int ethtool(const char *ifname, void *data)
 {
@@ -464,6 +479,180 @@ static struct memory_provider udmabuf_memory_provider = {
 };
 
 static struct memory_provider *rxmp = &udmabuf_memory_provider;
+
+#ifdef USE_CUDA
+
+ /* Length of str: 'XXXX:XX:XX' */
+#define MAX_BUS_ID_LEN 11
+
+static int cuda_find_device(__u16 domain, __u8 bus, __u8 device)
+{
+	char bus_id[MAX_BUS_ID_LEN];
+	int devnum;
+	int ret;
+
+	ret = snprintf(bus_id, MAX_BUS_ID_LEN, "%hx:%hhx:%hhx", domain, bus, device);
+	if (ret < 0)
+		return -EINVAL;
+
+	ret = cudaDeviceGetByPCIBusId(&devnum, bus_id);
+	if (ret != cudaSuccess) {
+		warnx("No CUDA device found %s", bus_id);
+		return -EINVAL;
+	}
+
+	return devnum;
+}
+
+static int cuda_dev_init(struct pci_dev *dev)
+{
+	struct cudaDeviceProp deviceProp;
+	CUdevice cuda_dev;
+	int devnum;
+	int ret;
+	int ok;
+
+	ret = cuInit(0);
+	if (ret != CUDA_SUCCESS)
+		return -1;
+
+	/* If the user did not specify a device, select any device */
+	if (dev->domain == DEVICE_DOMAIN_ANY && dev->bus == DEVICE_BUS_ANY && dev->device == DEVICE_DEVICE_ANY) {
+		devnum = 0;
+	} else {
+		devnum = cuda_find_device(dev->domain, dev->bus, dev->device);
+		if (devnum < 0)
+			return -1;
+	}
+
+	ret = cuDeviceGet(&cuda_dev, devnum);
+	if (ret != CUDA_SUCCESS)
+		return -1;
+
+	ok = 0;
+	ret = cuDeviceGetAttribute(&ok, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED,
+				   cuda_dev);
+	if (ret != CUDA_SUCCESS || !ok) {
+		if (!ok)
+			warnx("CUDA device does not support dmabuf");
+		return -1;
+	}
+
+	ret = cudaSetDevice(devnum);
+	if (ret != cudaSuccess) {
+		warn("cudaSetDevice() failed with error %d", ret);
+		return -1;
+	}
+
+	if (verbose >= 4)
+		fprintf(stderr, "cuda: tid %d selecting device %d (%s)\n",
+			getpid(), devnum, deviceProp.name);
+
+	return 0;
+}
+
+static struct memory_buffer *cuda_alloc(size_t size)
+{
+	struct memory_buffer *mem;
+	size_t page_size;
+	CUcontext ctx;
+	CUdevice dev;
+	int devnum;
+	int ret;
+
+	page_size = sysconf(_SC_PAGESIZE);
+	if (size % page_size) {
+		warnx("cuda memory size not aligned, size 0x%lx", size);
+		return NULL;
+	}
+
+	ret = cudaGetDevice(&devnum);
+	if (ret != cudaSuccess)
+		return NULL;
+
+	ret = cuDeviceGet(&dev, devnum);
+	if (ret != CUDA_SUCCESS)
+		return NULL;
+
+	ret = cuCtxCreate(&ctx, 0, dev);
+	if (ret != CUDA_SUCCESS)
+		return NULL;
+
+	mem = calloc(1, sizeof(*mem));
+	if (!mem)
+		goto destroy_ctx;
+
+	mem->size = size;
+
+	ret = cuMemAlloc((CUdeviceptr *)&mem->buf_mem, size);
+	if (ret != CUDA_SUCCESS)
+		goto free_mem;
+
+	ret = cuMemGetHandleForAddressRange((void *)&mem->fd, ((CUdeviceptr)mem->buf_mem),
+					    size, CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+					    CUDA_FLAGS);
+	if (ret != CUDA_SUCCESS)
+		goto free_cuda;
+
+	mem->valid = true;
+
+	return mem;
+
+free_cuda:
+	if (cuMemFree((CUdeviceptr)mem->buf_mem) != CUDA_SUCCESS)
+		warnx("cuMemFree() failed");
+free_mem:
+	free(mem);
+destroy_ctx:
+	if (cuCtxDestroy(ctx) != CUDA_SUCCESS)
+		warnx("cuCtxDestroy() failed");
+
+	return NULL;
+}
+
+static void cuda_free(struct memory_buffer *mem)
+{
+	if (mem->valid) {
+		close(mem->fd);
+		close(mem->memfd);
+		close(mem->devfd);
+		munmap(mem->buf_mem, mem->size);
+		mem->valid = false;
+	}
+}
+
+void cuda_memcpy_to_device(struct memory_buffer *dst, size_t off,
+			   void *src, int n)
+{
+	int ret;
+
+	ret = cuMemcpyHtoD((CUdeviceptr)(dst->buf_mem + off), src, n);
+	if (ret != CUDA_SUCCESS)
+		warnx("cuMemcpyHtoD() failed");
+}
+
+static struct memory_provider cuda_memory_provider = {
+	.dev_init = cuda_dev_init,
+	.alloc = cuda_alloc,
+	.free = cuda_free,
+	.memcpy_to_device = cuda_memcpy_to_device,
+};
+#endif
+
+static struct memory_provider *get_memory_provider(enum memory_provider_type provider)
+{
+	switch (provider) {
+	case MEMORY_PROVIDER_HOST:
+		return &udmabuf_memory_provider;
+#ifdef USE_CUDA
+	case MEMORY_PROVIDER_CUDA:
+		return &cuda_memory_provider;
+#endif
+	default:
+		warn("invalid provider: %d", provider);
+		return NULL;
+	}
+}
 
 /* Setup Devmem RX */
 int devmem_setup(struct session_state_devmem *devmem, int fd,

--- a/devmem.c
+++ b/devmem.c
@@ -315,34 +315,43 @@ static int udmabuf_check_size(size_t size_mb)
 	return ret;
 }
 
-static int udmabuf_alloc(struct memory_buffer *mem, const char *name, size_t size_mb)
+static struct memory_buffer *udmabuf_alloc(size_t size)
 {
 	struct udmabuf_create create;
+	struct memory_buffer *mem;
 	int ret;
 
-	ret = udmabuf_check_size(size_mb);
-	if (ret < 0)
-		return ret;
+	mem = calloc(1, sizeof(*mem));
+	if (!mem)
+		return NULL;
+
+	ret = udmabuf_check_size(size / 1024 / 1024);
+	if (ret < 0) {
+		warnx("Failed: udmabuf_check_size(), ret=%d", ret);
+		goto free_mem;
+	}
 
 	mem->devfd = open("/dev/udmabuf", O_RDWR);
-	if (mem->devfd < 0)
-		return -errno;
+	if (mem->devfd < 0) {
+		warn("Failed to open /dev/udmabuf");
+		goto free_mem;
+	}
 
-	mem->memfd = memfd_create(name, MFD_ALLOW_SEALING);
+	mem->memfd = memfd_create("udmabuf-test", MFD_ALLOW_SEALING);
 	if (mem->memfd < 0) {
-		ret = -errno;
+		warn("memfd_create() failed");
 		goto close_devfd;
 	}
 
 	ret = fcntl(mem->memfd, F_ADD_SEALS, F_SEAL_SHRINK);
 	if (ret < 0) {
-		ret = -errno;
+		warn("fcntl() failed");
 		goto close_memfd;
 	}
 
-	ret = ftruncate(mem->memfd, size_mb * 1024 * 1024);
+	ret = ftruncate(mem->memfd, size);
 	if (ret < 0) {
-		ret = -errno;
+		warn("ftruncate() failed");
 		goto close_memfd;
 	}
 
@@ -350,15 +359,15 @@ static int udmabuf_alloc(struct memory_buffer *mem, const char *name, size_t siz
 
 	create.memfd = mem->memfd;
 	create.offset = 0;
-	create.size = size_mb * 1024 * 1024;
+	create.size = size;
 
         mem->fd = ioctl(mem->devfd, UDMABUF_CREATE, &create);
         if (mem->fd < 0) {
-		ret = -errno;
+		warn("ioctl(mem->devfd) failed");
 		goto close_memfd;
 	}
 
-	mem->size = size_mb * 1024 * 1024;
+	mem->size = size;
 	mem->buf_mem = mmap(NULL, mem->size, PROT_READ | PROT_WRITE,
 				  MAP_SHARED, mem->fd, 0);
 
@@ -369,7 +378,7 @@ static int udmabuf_alloc(struct memory_buffer *mem, const char *name, size_t siz
 
 	mem->valid = true;
 
-	return 0;
+	return mem;
 
 close_dmabuf_fd:
 	close(mem->fd);
@@ -377,8 +386,9 @@ close_memfd:
 	close(mem->memfd);
 close_devfd:
 	close(mem->devfd);
-
-	return ret;
+free_mem:
+	free(mem);
+	return NULL;
 }
 
 static void udmabuf_free(struct memory_buffer *mem)
@@ -433,6 +443,29 @@ static int find_iface(struct sockaddr_in6 *addr, char ifname[IFNAMSIZ])
 	return -ENODEV;
 }
 
+void udmabuf_memcpy_to_device(struct memory_buffer *dst, size_t off,
+			      void *src, int n)
+{
+	struct dma_buf_sync sync = {};
+
+	sync.flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_WRITE;
+	ioctl(dst->fd, DMA_BUF_IOCTL_SYNC, &sync);
+
+	memcpy(dst->buf_mem + off, src, n);
+
+	sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_WRITE;
+	ioctl(dst->fd, DMA_BUF_IOCTL_SYNC, &sync);
+}
+
+static struct memory_provider udmabuf_memory_provider = {
+	.alloc = udmabuf_alloc,
+	.free = udmabuf_free,
+	.memcpy_to_device = udmabuf_memcpy_to_device,
+};
+
+static struct memory_provider *rxmp = &udmabuf_memory_provider;
+
+/* Setup Devmem RX */
 int devmem_setup(struct session_state_devmem *devmem, int fd,
 		 size_t udmabuf_size_mb, int num_queues)
 {
@@ -479,9 +512,9 @@ int devmem_setup(struct session_state_devmem *devmem, int fd,
 		goto sock_destroy;
 	}
 
-	ret = udmabuf_alloc(&devmem->mem, "udmabuf-test-rx", udmabuf_size_mb);
-	if (ret < 0) {
-		warnx("Failed to allocate udmabuf: %s", strerror(-ret));
+	devmem->mem = rxmp->alloc(udmabuf_size_mb * 1024 * 1024);
+	if (!devmem->mem) {
+		warnx("Failed to allocate udmabuf");
 		ret = -1;
 		goto sock_destroy;
 	}
@@ -524,9 +557,9 @@ int devmem_setup(struct session_state_devmem *devmem, int fd,
 		queues[i].id = max_kernel_queue + i;
 	}
 
-        devmem->mem.dmabuf_id = bind_rx_queue(ifindex, devmem->mem.fd, queues,
+        devmem->mem->dmabuf_id = bind_rx_queue(ifindex, devmem->mem->fd, queues,
                                           num_queues, devmem->ys);
-        if (devmem->mem.dmabuf_id < 0) {
+        if (devmem->mem->dmabuf_id < 0) {
 		warnx("Failed to bind RX queue");
 		ret = -1;
 		goto free_queues;
@@ -541,7 +574,7 @@ undo_rss_context:
 undo_rss:
 	rss_equal(ifname, rxqn);
 free_udmabuf:
-	udmabuf_free(&devmem->mem);
+	rxmp->free(devmem->mem);
 sock_destroy:
 	ynl_sock_destroy(devmem->ys);
 	devmem->ys = NULL;
@@ -564,7 +597,7 @@ int devmem_teardown(struct session_state_devmem *devmem)
 	}
 	if (devmem->ys)
 		ynl_sock_destroy(devmem->ys);
-	udmabuf_free(&devmem->mem);
+	rxmp->free(devmem->mem);
 	return 0;
 }
 

--- a/devmem.c
+++ b/devmem.c
@@ -307,6 +307,43 @@ out:
 	return ret;
 }
 
+static int bind_tx_queue(unsigned int ifindex, unsigned int dmabuf_fd,
+			 struct ynl_sock *ys)
+{
+	struct netdev_bind_tx_req *req = NULL;
+	struct netdev_bind_tx_rsp *rsp = NULL;
+	int ret;
+
+	req = netdev_bind_tx_req_alloc();
+	netdev_bind_tx_req_set_ifindex(req, ifindex);
+	netdev_bind_tx_req_set_fd(req, dmabuf_fd);
+
+	rsp = netdev_bind_tx(ys, req);
+	if (!rsp) {
+		warnx("netdev_bind_tx");
+		ret = -1;
+		goto free_req;
+	}
+
+	if (!rsp->_present.id) {
+		warnx("id not present");
+		ret = -1;
+		goto free_rsp;
+	}
+
+	ret = rsp->id;
+	netdev_bind_tx_req_free(req);
+	netdev_bind_tx_rsp_free(rsp);
+
+	return ret;
+
+free_rsp:
+	netdev_bind_tx_rsp_free(rsp);
+free_req:
+	netdev_bind_tx_req_free(req);
+	return ret;
+}
+
 #define UDMABUF_LIMIT_PATH "/sys/module/udmabuf/parameters/size_limit_mb"
 
 static int udmabuf_check_size(size_t size_mb)
@@ -479,6 +516,7 @@ static struct memory_provider udmabuf_memory_provider = {
 };
 
 static struct memory_provider *rxmp = &udmabuf_memory_provider;
+static struct memory_provider *txmp = &udmabuf_memory_provider;
 
 #ifdef USE_CUDA
 
@@ -934,4 +972,108 @@ ssize_t devmem_recv(int fd, struct connection_devmem *conn,
 	}
 
 	return n;
+}
+
+int devmem_sendmsg(int fd, struct connection_devmem *devmem, size_t off, size_t n)
+{
+	char ctrl_data[CMSG_SPACE(sizeof(int))];
+	struct msghdr msg = { 0 };
+	struct cmsghdr *cmsg;
+	struct iovec iov;
+
+	iov.iov_base = (void *)off;
+	iov.iov_len = n;
+
+	msg.msg_iov = &iov;
+	msg.msg_iovlen = 1;
+
+	msg.msg_control = ctrl_data;
+	msg.msg_controllen = sizeof(ctrl_data);
+
+	cmsg = CMSG_FIRSTHDR(&msg);
+	cmsg->cmsg_level = SOL_SOCKET;
+	cmsg->cmsg_type = SCM_DEVMEM_DMABUF;
+	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+	*((int *)CMSG_DATA(cmsg)) = devmem->mem->dmabuf_id;
+
+	return sendmsg(fd, &msg, MSG_SOCK_DEVMEM);
+}
+
+/* Setup Devmem TX */
+int devmem_setup_conn(int fd, struct connection_devmem *devmem)
+{
+	char ifname[IFNAMSIZ] = {};
+	struct sockaddr_in6 addr;
+	struct ynl_error yerr;
+	socklen_t optlen;
+	int ifindex;
+	int opt = 1;
+	int ret;
+
+	devmem->ys = ynl_sock_create(&ynl_netdev_family, &yerr);
+	if (!devmem->ys) {
+		warnx("Failed to setup YNL socket: %s", yerr.msg);
+		return -1;
+	}
+
+	optlen = sizeof(addr);
+	if (getsockname(fd, (struct sockaddr *)&addr, &optlen) < 0) {
+		warn("Failed to query socket address");
+		ret = -1;
+		goto sock_destroy;
+	}
+
+	if (addr.sin6_family == AF_INET)
+		inet_to_inet6((void *)&addr, &addr);
+
+	ifindex = find_iface(&addr, ifname);
+	if (ifindex < 0) {
+		warnx("Failed to resolve ifindex: %s", strerror(-ifindex));
+		ret = -1;
+		goto sock_destroy;
+	}
+
+	devmem->mem = txmp->alloc(ROUND_UP(sizeof(patbuf), 1024 * 1024));
+	if (!devmem->mem) {
+		warnx("Failed to allocate devmem tx buffer");
+		ret = -1;
+		goto sock_destroy;
+	}
+
+	devmem->mem->dmabuf_id = bind_tx_queue(ifindex, devmem->mem->fd,
+					      devmem->ys);
+	if (devmem->mem->dmabuf_id < 0) {
+		ret = -1;
+		goto free_udmabuf;
+	}
+
+	txmp->memcpy_to_device(devmem->mem, 0, patbuf, sizeof(patbuf));
+
+	if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, ifname, IFNAMSIZ)) {
+		warn("failed to bind device to socket");
+		ret = -1;
+		goto free_udmabuf;
+	}
+
+	if (setsockopt(fd, SOL_SOCKET, SO_ZEROCOPY, &opt, sizeof(opt))) {
+		warnx("failed to set SO_ZEROCOPY");
+		ret = -1;
+		goto free_udmabuf;
+	}
+
+	return 0;
+
+free_udmabuf:
+	txmp->free(devmem->mem);
+sock_destroy:
+	ynl_sock_destroy(devmem->ys);
+	devmem->ys = NULL;
+	return ret;
+}
+
+void devmem_teardown_conn(struct connection_devmem *devmem)
+{
+	txmp->free(devmem->mem);
+	ynl_sock_destroy(devmem->ys);
+	devmem->ys = NULL;
 }

--- a/devmem.c
+++ b/devmem.c
@@ -40,9 +40,10 @@
 #endif
 #endif
 
-#define ROUND_UP(n, d) ((((n) + (d) - 1) / (d)) * (d))
-
 extern unsigned char patbuf[KPM_MAX_OP_CHUNK + PATTERN_PERIOD + 1];
+
+static struct memory_provider *rxmp;
+static struct memory_provider *txmp;
 
 extern int verbose;
 
@@ -515,9 +516,6 @@ static struct memory_provider udmabuf_memory_provider = {
 	.memcpy_to_device = udmabuf_memcpy_to_device,
 };
 
-static struct memory_provider *rxmp = &udmabuf_memory_provider;
-static struct memory_provider *txmp = &udmabuf_memory_provider;
-
 #ifdef USE_CUDA
 
  /* Length of str: 'XXXX:XX:XX' */
@@ -690,6 +688,25 @@ static struct memory_provider *get_memory_provider(enum memory_provider_type pro
 		warn("invalid provider: %d", provider);
 		return NULL;
 	}
+}
+
+int devmem_setup_tx(struct session_state_devmem *devmem, enum memory_provider_type provider, struct pci_dev *dev, size_t udmabuf_size_mb)
+{
+	txmp = get_memory_provider(provider);
+	if (!txmp)
+		return -1;
+
+	if (txmp->dev_init && txmp->dev_init(dev) < 0)
+		return -1;
+
+	devmem->tx_mem = txmp->alloc(udmabuf_size_mb * 1024 * 1024);
+	if (!devmem->tx_mem) {
+		warnx("Failed to allocate devmem tx buffer");
+		return -1;
+	}
+
+	txmp->memcpy_to_device(devmem->tx_mem, 0, patbuf, sizeof(patbuf));
+	return 0;
 }
 
 /* Setup Devmem RX */
@@ -980,6 +997,12 @@ int devmem_sendmsg(int fd, struct connection_devmem *devmem, size_t off, size_t 
 	struct msghdr msg = { 0 };
 	struct cmsghdr *cmsg;
 	struct iovec iov;
+	int opt = 1;
+
+	if (setsockopt(fd, SOL_SOCKET, SO_ZEROCOPY, &opt, sizeof(opt))) {
+		warnx("failed to set SO_ZEROCOPY");
+		return -1;
+	}
 
 	iov.iov_base = (void *)off;
 	iov.iov_len = n;
@@ -994,33 +1017,25 @@ int devmem_sendmsg(int fd, struct connection_devmem *devmem, size_t off, size_t 
 	cmsg->cmsg_level = SOL_SOCKET;
 	cmsg->cmsg_type = SCM_DEVMEM_DMABUF;
 	cmsg->cmsg_len = CMSG_LEN(sizeof(int));
-	*((int *)CMSG_DATA(cmsg)) = devmem->mem->dmabuf_id;
+	*((int *)CMSG_DATA(cmsg)) = devmem->tx_mem.dmabuf_id;
 
 	return sendmsg(fd, &msg, MSG_SOCK_DEVMEM);
 }
 
 /* Setup Devmem TX */
-int devmem_setup_conn(int fd, struct connection_devmem *devmem)
+int devmem_setup_conn(int fd, struct connection_devmem *devmem, int dmabuf_fd)
 {
 	char ifname[IFNAMSIZ] = {};
 	struct sockaddr_in6 addr;
 	struct ynl_error yerr;
 	socklen_t optlen;
 	int ifindex;
-	int opt = 1;
 	int ret;
-
-	devmem->ys = ynl_sock_create(&ynl_netdev_family, &yerr);
-	if (!devmem->ys) {
-		warnx("Failed to setup YNL socket: %s", yerr.msg);
-		return -1;
-	}
 
 	optlen = sizeof(addr);
 	if (getsockname(fd, (struct sockaddr *)&addr, &optlen) < 0) {
 		warn("Failed to query socket address");
-		ret = -1;
-		goto sock_destroy;
+		return -1;
 	}
 
 	if (addr.sin6_family == AF_INET)
@@ -1029,51 +1044,46 @@ int devmem_setup_conn(int fd, struct connection_devmem *devmem)
 	ifindex = find_iface(&addr, ifname);
 	if (ifindex < 0) {
 		warnx("Failed to resolve ifindex: %s", strerror(-ifindex));
-		ret = -1;
-		goto sock_destroy;
+		return -1;
 	}
 
-	devmem->mem = txmp->alloc(ROUND_UP(sizeof(patbuf), 1024 * 1024));
-	if (!devmem->mem) {
-		warnx("Failed to allocate devmem tx buffer");
-		ret = -1;
-		goto sock_destroy;
+	devmem->ys = ynl_sock_create(&ynl_netdev_family, &yerr);
+
+	if (!devmem->ys) {
+		warnx("Failed to setup YNL socket: %s", yerr.msg);
+		return -1;
 	}
 
-	devmem->mem->dmabuf_id = bind_tx_queue(ifindex, devmem->mem->fd,
+	devmem->tx_mem.fd = dmabuf_fd;
+	devmem->tx_mem.dmabuf_id = bind_tx_queue(ifindex, devmem->tx_mem.fd,
 					      devmem->ys);
-	if (devmem->mem->dmabuf_id < 0) {
+	if (devmem->tx_mem.dmabuf_id < 0) {
 		ret = -1;
-		goto free_udmabuf;
+		goto sock_destroy;
 	}
-
-	txmp->memcpy_to_device(devmem->mem, 0, patbuf, sizeof(patbuf));
 
 	if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, ifname, IFNAMSIZ)) {
 		warn("failed to bind device to socket");
 		ret = -1;
-		goto free_udmabuf;
-	}
-
-	if (setsockopt(fd, SOL_SOCKET, SO_ZEROCOPY, &opt, sizeof(opt))) {
-		warnx("failed to set SO_ZEROCOPY");
-		ret = -1;
-		goto free_udmabuf;
+		goto sock_destroy;
 	}
 
 	return 0;
 
-free_udmabuf:
-	txmp->free(devmem->mem);
 sock_destroy:
 	ynl_sock_destroy(devmem->ys);
 	devmem->ys = NULL;
 	return ret;
 }
 
+void devmem_teardown_tx(struct session_state_devmem *devmem)
+{
+	if (txmp)
+		txmp->free(devmem->tx_mem);
+}
+
 void devmem_teardown_conn(struct connection_devmem *devmem)
 {
-	txmp->free(devmem->mem);
 	ynl_sock_destroy(devmem->ys);
 	devmem->ys = NULL;
 }

--- a/devmem.c
+++ b/devmem.c
@@ -656,7 +656,9 @@ static struct memory_provider *get_memory_provider(enum memory_provider_type pro
 
 /* Setup Devmem RX */
 int devmem_setup(struct session_state_devmem *devmem, int fd,
-		 size_t udmabuf_size_mb, int num_queues)
+		 size_t udmabuf_size_mb, int num_queues,
+		 enum memory_provider_type provider,
+		 struct pci_dev *dev)
 {
 	struct netdev_queue_id *queues;
 	char ifname[IFNAMSIZ] = {};
@@ -678,6 +680,10 @@ int devmem_setup(struct session_state_devmem *devmem, int fd,
 		warn("Failed to query socket address");
 		return -1;
 	}
+
+	rxmp = get_memory_provider(provider);
+	if (!rxmp)
+		return -1;
 
 	if (addr.sin6_family == AF_INET)
 		inet_to_inet6((void *)&addr, &addr);
@@ -701,9 +707,14 @@ int devmem_setup(struct session_state_devmem *devmem, int fd,
 		goto sock_destroy;
 	}
 
+	if (rxmp->dev_init && rxmp->dev_init(dev) < 0) {
+		ret = -1;
+		goto sock_destroy;
+	}
+
 	devmem->mem = rxmp->alloc(udmabuf_size_mb * 1024 * 1024);
 	if (!devmem->mem) {
-		warnx("Failed to allocate udmabuf");
+		warnx("Failed to allocate memory");
 		ret = -1;
 		goto sock_destroy;
 	}
@@ -712,7 +723,7 @@ int devmem_setup(struct session_state_devmem *devmem, int fd,
 		warnx("Invalid number of RX queues (%u) requested (max: %u)",
 		      num_queues, rxqn - 1);
 		ret = -1;
-		goto free_udmabuf;
+		goto free_memory;
 	}
 
 	max_kernel_queue = rxqn - num_queues;
@@ -721,7 +732,7 @@ int devmem_setup(struct session_state_devmem *devmem, int fd,
 	if (rss_equal(ifname, max_kernel_queue)) {
 		warnx("Failed to setup RSS");
 		ret = -1;
-		goto free_udmabuf;
+		goto free_memory;
 	}
 
 	memcpy(devmem->ifname, ifname, IFNAMSIZ);
@@ -762,7 +773,7 @@ undo_rss_context:
 	rss_context_delete(devmem);
 undo_rss:
 	rss_equal(ifname, rxqn);
-free_udmabuf:
+free_memory:
 	rxmp->free(devmem->mem);
 sock_destroy:
 	ynl_sock_destroy(devmem->ys);
@@ -786,7 +797,8 @@ int devmem_teardown(struct session_state_devmem *devmem)
 	}
 	if (devmem->ys)
 		ynl_sock_destroy(devmem->ys);
-	rxmp->free(devmem->mem);
+	if (rxmp)
+		rxmp->free(devmem->mem);
 	return 0;
 }
 
@@ -828,6 +840,7 @@ static int devmem_validate_token(struct memory_buffer *mem,
 	ioctl(mem->fd, DMA_BUF_IOCTL_SYNC, &sync);
 
 	pat = &patbuf[start];
+	/* TODO: memory_provider for CUDA case? */
 	ret = memcmp(pat, mem->buf_mem + dmabuf_cmsg->frag_offset, dmabuf_cmsg->frag_size);
 
 	sync.flags = DMA_BUF_SYNC_END;

--- a/proto.c
+++ b/proto.c
@@ -181,7 +181,9 @@ int kpm_send_tcp_cc(int fd, __u32 id, char *cc_name)
 }
 
 int kpm_send_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-		  __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate)
+		  __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate,
+		  enum memory_provider_type rx_provider,
+		  struct pci_dev *dev)
 {
 	struct kpm_mode msg = {};
 
@@ -190,6 +192,9 @@ int kpm_send_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
 	msg.udmabuf_size_mb = udmabuf_size_mb;
 	msg.num_rx_queues = num_rx_queues;
 	msg.validate = validate;
+	msg.rx_provider = rx_provider;
+
+	memcpy(&msg.dev, dev, sizeof(msg.dev));
 
 	return kpm_send(fd, &msg.hdr, sizeof(msg), KPM_MSG_TYPE_MODE);
 }
@@ -459,12 +464,15 @@ kpm_req_tcp_cc(int fd, __u32 conn_id, char *cc_name)
 
 int
 kpm_req_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-	     __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate)
+	     __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate,
+	     enum memory_provider_type rx_provider,
+	     struct pci_dev *dev)
 {
 	struct kpm_empty *repl;
 	int id;
 
-	id = kpm_send_mode(fd, rx_mode, tx_mode, udmabuf_size_mb, num_rx_queues, validate);
+	id = kpm_send_mode(fd, rx_mode, tx_mode, udmabuf_size_mb, num_rx_queues, validate,
+			   rx_provider, dev);
 	if (id < 0) {
 		warnx("Failed to request mode");
 		return id;

--- a/proto.c
+++ b/proto.c
@@ -183,6 +183,7 @@ int kpm_send_tcp_cc(int fd, __u32 id, char *cc_name)
 int kpm_send_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
 		  __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate,
 		  enum memory_provider_type rx_provider,
+		  enum memory_provider_type tx_provider,
 		  struct pci_dev *dev)
 {
 	struct kpm_mode msg = {};
@@ -193,6 +194,7 @@ int kpm_send_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
 	msg.num_rx_queues = num_rx_queues;
 	msg.validate = validate;
 	msg.rx_provider = rx_provider;
+	msg.tx_provider = tx_provider;
 
 	memcpy(&msg.dev, dev, sizeof(msg.dev));
 
@@ -466,13 +468,14 @@ int
 kpm_req_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
 	     __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate,
 	     enum memory_provider_type rx_provider,
+	     enum memory_provider_type tx_provider,
 	     struct pci_dev *dev)
 {
 	struct kpm_empty *repl;
 	int id;
 
 	id = kpm_send_mode(fd, rx_mode, tx_mode, udmabuf_size_mb, num_rx_queues, validate,
-			   rx_provider, dev);
+			   rx_provider, tx_provider, dev);
 	if (id < 0) {
 		warnx("Failed to request mode");
 		return id;

--- a/proto.h
+++ b/proto.h
@@ -133,6 +133,11 @@ enum kpm_tx_mode {
 	KPM_TX_MODE_SOCKET_ZEROCOPY,
 };
 
+enum memory_provider_type {
+	MEMORY_PROVIDER_HOST,
+	MEMORY_PROVIDER_CUDA,
+};
+
 #define DEVICE_DOMAIN_ANY 0xffff
 #define DEVICE_BUS_ANY 0xff
 #define DEVICE_DEVICE_ANY 0xff
@@ -147,8 +152,13 @@ struct kpm_mode {
 	struct kpm_header hdr;
 	enum kpm_rx_mode rx_mode;
 	enum kpm_tx_mode tx_mode;
+
+	/* devmem info */
+	enum memory_provider_type rx_provider;
+	struct pci_dev dev;
 	__u32 udmabuf_size_mb;
 	__u32 num_rx_queues;
+
 	__u8 validate;
 };
 
@@ -284,7 +294,9 @@ int kpm_send_tls(int fd, __u32 conn_id, __u32 dir_mask,
 int kpm_send_max_pacing(int fd, __u32 id, __u32 max_pace);
 int kpm_send_tcp_cc(int fd, __u32 id, char *cc_name);
 int kpm_send_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-		  __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate);
+		  __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate,
+		  enum memory_provider_type rx_provider,
+		  struct pci_dev *dev);
 int kpm_send_pin_worker(int fd, __u32 id, __u32 cpu);
 
 void kpm_reply_error(int fd, struct kpm_header *hdr, __u16 error);
@@ -308,7 +320,9 @@ int kpm_req_tls(int fd, __u32 conn_id, __u32 dir_mask,
 int kpm_req_pacing(int fd, __u32 conn_id, __u32 max_pace);
 int kpm_req_tcp_cc(int fd, __u32 conn_id, char *cc_name);
 int kpm_req_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-		 __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate);
+		 __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate,
+		 enum memory_provider_type rx_provider,
+		 struct pci_dev *dev);
 int kpm_req_disconnect(int fd, __u32 connection_id);
 
 #endif /* PROTO_H */

--- a/proto.h
+++ b/proto.h
@@ -133,6 +133,16 @@ enum kpm_tx_mode {
 	KPM_TX_MODE_SOCKET_ZEROCOPY,
 };
 
+#define DEVICE_DOMAIN_ANY 0xffff
+#define DEVICE_BUS_ANY 0xff
+#define DEVICE_DEVICE_ANY 0xff
+
+struct pci_dev {
+	__u16 domain;
+	__u8 bus;
+	__u8 device;
+};
+
 struct kpm_mode {
 	struct kpm_header hdr;
 	enum kpm_rx_mode rx_mode;

--- a/proto.h
+++ b/proto.h
@@ -131,6 +131,7 @@ enum kpm_rx_mode {
 enum kpm_tx_mode {
 	KPM_TX_MODE_SOCKET,
 	KPM_TX_MODE_SOCKET_ZEROCOPY,
+	KPM_TX_MODE_DEVMEM,
 };
 
 enum memory_provider_type {

--- a/proto.h
+++ b/proto.h
@@ -156,6 +156,7 @@ struct kpm_mode {
 
 	/* devmem info */
 	enum memory_provider_type rx_provider;
+	enum memory_provider_type tx_provider;
 	struct pci_dev dev;
 	__u32 udmabuf_size_mb;
 	__u32 num_rx_queues;
@@ -297,6 +298,7 @@ int kpm_send_tcp_cc(int fd, __u32 id, char *cc_name);
 int kpm_send_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
 		  __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate,
 		  enum memory_provider_type rx_provider,
+		  enum memory_provider_type tx_provider,
 		  struct pci_dev *dev);
 int kpm_send_pin_worker(int fd, __u32 id, __u32 cpu);
 
@@ -323,6 +325,7 @@ int kpm_req_tcp_cc(int fd, __u32 conn_id, char *cc_name);
 int kpm_req_mode(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
 		 __u32 udmabuf_size_mb, __u32 num_rx_queues, __u8 validate,
 		 enum memory_provider_type rx_provider,
+		 enum memory_provider_type tx_provider,
 		 struct pci_dev *dev);
 int kpm_req_disconnect(int fd, __u32 connection_id);
 

--- a/server.h
+++ b/server.h
@@ -47,6 +47,10 @@ struct memory_buffer {
 	char *buf_mem;
 	size_t size;
 	int fd;
+	int devfd;
+	int memfd;
+	int dmabuf_id;
+	bool valid;
 };
 
 struct connection_devmem {
@@ -60,11 +64,7 @@ struct session_state_devmem {
 	struct ynl_sock *ys;
 	char ifname[IFNAMSIZ];
 	struct memory_buffer mem;
-	int dmabuf_id;
-	int udmabuf_devfd;
-	int udmabuf_memfd;
 	int rss_context;
-	bool udmabuf_valid;
 };
 
 struct worker_state_devmem {

--- a/server.h
+++ b/server.h
@@ -96,4 +96,6 @@ ssize_t devmem_recv(int fd, struct connection_devmem *conn,
 		    unsigned char *rxbuf, size_t chunk, struct memory_buffer *mem,
 		    int rep, __u64 tot_recv, bool validate);
 
+void patbuf_init(void);
+
 #endif /* SERVER_H */

--- a/server.h
+++ b/server.h
@@ -88,7 +88,8 @@ void NORETURN pworker_main(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx
                            struct memory_buffer *devmem, bool validate);
 
 int devmem_setup(struct session_state_devmem *devmem, int fd,
-		 size_t udmabuf_size, int num_queues);
+		 size_t udmabuf_size, int num_queues,
+		 enum memory_provider_type provider, struct pci_dev *dev);
 int devmem_teardown(struct session_state_devmem *devmem);
 int devmem_release_tokens(int fd, struct connection_devmem *conn);
 ssize_t devmem_recv(int fd, struct connection_devmem *conn,

--- a/server.h
+++ b/server.h
@@ -68,7 +68,7 @@ struct connection_devmem {
 	int rxtok_len;
 	/* ncdevmem uses 80k, allocate 64k for recvmsg tokens */
 	char ctrl_data[64 * 1024];
-	struct memory_buffer *mem;
+	struct memory_buffer tx_mem;
 	struct ynl_sock *ys;
 };
 
@@ -76,29 +76,34 @@ struct session_state_devmem {
 	struct ynl_sock *ys;
 	char ifname[IFNAMSIZ];
 	struct memory_buffer *mem;
+	struct memory_buffer *tx_mem;
 	int rss_context;
 };
 
 struct worker_state_devmem {
 	struct memory_buffer *mem;
+	bool use_tx;
 };
 
 struct server_session *
 server_session_spawn(int fd, struct sockaddr_in6 *addr, socklen_t *addrlen);
 
 void NORETURN pworker_main(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-                           struct memory_buffer *devmem, bool validate);
+                           struct memory_buffer *devmem, bool validate,
+			   bool use_devmem_tx);
 
 int devmem_setup(struct session_state_devmem *devmem, int fd,
 		 size_t udmabuf_size, int num_queues,
 		 enum memory_provider_type provider, struct pci_dev *dev);
+int devmem_setup_tx(struct session_state_devmem *devmem, enum memory_provider_type provider, struct pci_dev *dev, size_t udmabuf_size);
 int devmem_teardown(struct session_state_devmem *devmem);
+void devmem_teardown_tx(struct session_state_devmem *devmem);
 int devmem_release_tokens(int fd, struct connection_devmem *conn);
 ssize_t devmem_recv(int fd, struct connection_devmem *conn,
 		    unsigned char *rxbuf, size_t chunk, struct memory_buffer *mem,
 		    int rep, __u64 tot_recv, bool validate);
 int devmem_sendmsg(int fd, struct connection_devmem *devmem, size_t off, size_t n);
-int devmem_setup_conn(int fd, struct connection_devmem *devmem);
+int devmem_setup_conn(int fd, struct connection_devmem *devmem, int dmabuf_fd);
 void devmem_teardown_conn(struct connection_devmem *devmem);
 
 void patbuf_init(void);

--- a/server.h
+++ b/server.h
@@ -68,6 +68,8 @@ struct connection_devmem {
 	int rxtok_len;
 	/* ncdevmem uses 80k, allocate 64k for recvmsg tokens */
 	char ctrl_data[64 * 1024];
+	struct memory_buffer *mem;
+	struct ynl_sock *ys;
 };
 
 struct session_state_devmem {
@@ -95,6 +97,9 @@ int devmem_release_tokens(int fd, struct connection_devmem *conn);
 ssize_t devmem_recv(int fd, struct connection_devmem *conn,
 		    unsigned char *rxbuf, size_t chunk, struct memory_buffer *mem,
 		    int rep, __u64 tot_recv, bool validate);
+int devmem_sendmsg(int fd, struct connection_devmem *devmem, size_t off, size_t n);
+int devmem_setup_conn(int fd, struct connection_devmem *devmem);
+void devmem_teardown_conn(struct connection_devmem *devmem);
 
 void patbuf_init(void);
 

--- a/server.h
+++ b/server.h
@@ -54,6 +54,7 @@ struct memory_buffer {
 };
 
 struct memory_provider {
+	int (*dev_init)(struct pci_dev *dev);
 	struct memory_buffer *(*alloc)(size_t size);
 	void (*free)(struct memory_buffer *mem);
 	void (*memcpy_to_device)(struct memory_buffer *dst, size_t off,

--- a/server.h
+++ b/server.h
@@ -53,6 +53,15 @@ struct memory_buffer {
 	bool valid;
 };
 
+struct memory_provider {
+	struct memory_buffer *(*alloc)(size_t size);
+	void (*free)(struct memory_buffer *mem);
+	void (*memcpy_to_device)(struct memory_buffer *dst, size_t off,
+				 void *src, int n);
+	void (*memcpy_from_device)(void *dst, struct memory_buffer *src,
+				   size_t off, int n);
+};
+
 struct connection_devmem {
 	struct dmabuf_token rxtok[128];
 	int rxtok_len;
@@ -63,12 +72,12 @@ struct connection_devmem {
 struct session_state_devmem {
 	struct ynl_sock *ys;
 	char ifname[IFNAMSIZ];
-	struct memory_buffer mem;
+	struct memory_buffer *mem;
 	int rss_context;
 };
 
 struct worker_state_devmem {
-	struct memory_buffer mem;
+	struct memory_buffer *mem;
 };
 
 struct server_session *

--- a/server_session.c
+++ b/server_session.c
@@ -513,7 +513,8 @@ server_msg_mode(struct session_state *self, struct kpm_header *hdr)
 
 	if (self->tcp_sock && req->rx_mode == KPM_RX_MODE_DEVMEM) {
 		ret = devmem_setup(&self->devmem, self->tcp_sock, req->udmabuf_size_mb,
-				   req->num_rx_queues);
+				   req->num_rx_queues, req->rx_provider,
+				   &req->dev);
 		if (ret < 0) {
 			warnx("Failed to setup devmem");
 			self->quit = 1;

--- a/server_session.c
+++ b/server_session.c
@@ -560,7 +560,7 @@ server_msg_spawn_pworker(struct session_state *self, struct kpm_header *hdr)
 	}
 	if (!pwrk->pid) {
 		close(p[0]);
-		pworker_main(p[1], self->rx_mode, self->tx_mode, &self->devmem.mem,
+		pworker_main(p[1], self->rx_mode, self->tx_mode, self->devmem.mem,
 			     self->validate);
 		exit(1);
 	}

--- a/server_session.c
+++ b/server_session.c
@@ -978,6 +978,13 @@ static void server_session_loop(int fd)
 	struct epoll_event ev = {}, events[32];
 	struct connection *conn, *next;
 
+	/*
+	 * Initialize the pattern before doing any TX setup. Some TX modes
+	 * (e.g., devmem) copy this pattern before fork(), so we need to initialize
+	 * it early.
+	 */
+	patbuf_init();
+
 	list_head_init(&self.connections);
 	list_head_init(&self.pworkers);
 	list_head_init(&self.tests);

--- a/server_session.c
+++ b/server_session.c
@@ -74,6 +74,15 @@ struct test {
 	struct list_node tests;
 };
 
+/*
+ * Returns true if a session is configured to be a devmem RX destination. Otherwise,
+ * returns false.
+ */
+static bool server_session_devmem_rx(struct session_state *self, enum kpm_rx_mode mode)
+{
+	return self->tcp_sock && (mode == KPM_RX_MODE_DEVMEM);
+}
+
 static struct connection *
 session_find_connection_by_id(struct session_state *self, unsigned int id)
 {
@@ -511,7 +520,7 @@ server_msg_mode(struct session_state *self, struct kpm_header *hdr)
 	}
 	req = (void *)hdr;
 
-	if (self->tcp_sock && req->rx_mode == KPM_RX_MODE_DEVMEM) {
+	if (server_session_devmem_rx(self, req->rx_mode)) {
 		ret = devmem_setup(&self->devmem, self->tcp_sock, req->udmabuf_size_mb,
 				   req->num_rx_queues, req->rx_provider,
 				   &req->dev);
@@ -1024,7 +1033,7 @@ static void server_session_loop(int fd)
 		list_del(&conn->connections);
 		free(conn);
 	}
-	if (self.tcp_sock && self.rx_mode == KPM_RX_MODE_DEVMEM)
+	if (server_session_devmem_rx(&self, self.rx_mode))
 		devmem_teardown(&self.devmem);
 }
 

--- a/server_session.c
+++ b/server_session.c
@@ -75,6 +75,18 @@ struct test {
 };
 
 /*
+ * Returns true if a session is configured to be a devmem TX source. Otherwise,
+ * returns false.
+ *
+ * This function is unable to use self->devmem.tx_mem state because it must
+ * support being called before tx_mem is allocated.
+ */
+static bool server_session_devmem_tx(struct session_state *self, enum kpm_tx_mode mode)
+{
+	return !self->tcp_sock && (mode == KPM_TX_MODE_DEVMEM);
+}
+
+/*
  * Returns true if a session is configured to be a devmem RX destination. Otherwise,
  * returns false.
  */
@@ -531,6 +543,23 @@ server_msg_mode(struct session_state *self, struct kpm_header *hdr)
 		}
 	}
 
+	/*
+	 * Initialize the pattern before doing any TX setup. Some TX modes
+	 * (e.g., devmem) copy this pattern before fork(), so we need to initialize
+	 * now before TX mode-specific setup.
+	 */
+	patbuf_init();
+
+	if (server_session_devmem_tx(self, req->tx_mode)) {
+		ret = devmem_setup_tx(&self->devmem, req->tx_provider, &req->dev,
+				      req->udmabuf_size_mb);
+		if (ret < 0) {
+			warnx("Failed to setup devmem_tx");
+			self->quit = 1;
+			return;
+		}
+	}
+
 	self->rx_mode = req->rx_mode;
 	self->tx_mode = req->tx_mode;
 	self->validate = req->validate;
@@ -571,7 +600,7 @@ server_msg_spawn_pworker(struct session_state *self, struct kpm_header *hdr)
 	if (!pwrk->pid) {
 		close(p[0]);
 		pworker_main(p[1], self->rx_mode, self->tx_mode, self->devmem.mem,
-			     self->validate);
+			     self->validate, server_session_devmem_tx(self, self->tx_mode));
 		exit(1);
 	}
 
@@ -740,9 +769,12 @@ bad_req:
 			 KPM_MSG_WORKER_TEST);
 		for (j = 0; j < msg->n_conns; j++) {
 			conn = session_find_connection_by_id(self, msg->specs[j].connection_id);
+
 			fdpass_send(pwrk->fd, conn->fd);
 			/* close to ensure the only open descriptors are owned by the worker. */
 			close(conn->fd);
+			if (server_session_devmem_tx(self, self->tx_mode))
+				fdpass_send(pwrk->fd, self->devmem.tx_mem->fd);
 		}
 	}
 
@@ -1035,6 +1067,8 @@ static void server_session_loop(int fd)
 	}
 	if (server_session_devmem_rx(&self, self.rx_mode))
 		devmem_teardown(&self.devmem);
+	if (server_session_devmem_tx(&self, self.tx_mode))
+		devmem_teardown_tx(&self.devmem);
 }
 
 static NORETURN void server_session(int fd)

--- a/worker.c
+++ b/worker.c
@@ -656,7 +656,7 @@ worker_handle_recv(struct worker_state *self, struct connection *conn)
 		chunk = min_t(size_t, conn->read_size, conn->to_recv);
 		if (self->rx_mode == KPM_RX_MODE_DEVMEM)
 			n = devmem_recv(conn->fd, &conn->devmem,
-					conn->rxbuf, chunk, &self->devmem.mem,
+					conn->rxbuf, chunk, self->devmem.mem,
 					rep, conn->tot_recv, self->validate);
 		else
 			n = worker_handle_regular_recv(self, conn, chunk, rep,
@@ -730,12 +730,11 @@ void NORETURN pworker_main(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx
 		.rx_mode = rx_mode,
 		.tx_mode = tx_mode,
 		.validate = validate,
+		.devmem = { .mem = devmem },
 	};
 	struct epoll_event ev, events[32];
 	unsigned char j;
 	int i, nfds;
-
-	memcpy(&self.devmem.mem, devmem, sizeof(self.devmem.mem));
 
 	list_head_init(&self.connections);
 

--- a/worker.c
+++ b/worker.c
@@ -69,10 +69,14 @@ struct connection {
 	struct list_node connections;
 };
 
-/* Returns true if worker is a devmem tx sender. Otherwise, returns false. */
+/* Returns true if both the server session is configured for
+ * KPM_TX_MODE_DEVMEM and this worker is a source. Otherwise, false.
+ *
+ * Should be derived from server_session_devmem_tx().
+ */
 static bool worker_devmem_tx(struct worker_state *self)
 {
-	return self->tx_mode == KPM_TX_MODE_DEVMEM;
+	return self->devmem.use_tx;
 }
 
 unsigned char patbuf[KPM_MAX_OP_CHUNK + PATTERN_PERIOD + 1];
@@ -280,6 +284,16 @@ worker_msg_test(struct worker_state *self, struct kpm_header *hdr)
 		conn->id = req->specs[i].connection_id;
 		conn->fd = fdpass_recv(self->main_sock);
 
+		/* Only devmem TX sessions/workers have a dmabuf fd to pass */
+		if (worker_devmem_tx(self)) {
+			int dmabuf_fd = fdpass_recv(self->main_sock);
+
+			if (devmem_setup_conn(conn->fd, &conn->devmem, dmabuf_fd) < 0) {
+				self->quit = 1;
+				return;
+			}
+		}
+
 		info_len = sizeof(conn->init_info);
 		if (getsockopt(conn->fd, IPPROTO_TCP, TCP_INFO,
 			       (void *)&conn->init_info, &info_len) < 0) {
@@ -337,13 +351,6 @@ worker_msg_test(struct worker_state *self, struct kpm_header *hdr)
 			warnx("Failed to set SO_ZEROCOPY");
 			self->quit = 1;
 			return;
-		}
-
-		if (worker_devmem_tx(self)) {
-			if (devmem_setup_conn(conn->fd, &conn->devmem) < 0) {
-				self->quit = 1;
-				return;
-			}
 		}
 
 		ev.events = EPOLLIN | EPOLLOUT;
@@ -759,14 +766,14 @@ void patbuf_init(void)
 /* == Main loop == */
 
 void NORETURN pworker_main(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
-			   struct memory_buffer *devmem, bool validate)
+			   struct memory_buffer *devmem, bool validate, bool use_devmem_tx)
 {
 	struct worker_state self = {
 		.main_sock = fd,
 		.rx_mode = rx_mode,
 		.tx_mode = tx_mode,
 		.validate = validate,
-		.devmem = { .mem = devmem },
+		.devmem = { .mem = devmem, .use_tx = use_devmem_tx },
 	};
 	struct epoll_event ev, events[32];
 	int i, nfds;

--- a/worker.c
+++ b/worker.c
@@ -69,6 +69,12 @@ struct connection {
 	struct list_node connections;
 };
 
+/* Returns true if worker is a devmem tx sender. Otherwise, returns false. */
+static bool worker_devmem_tx(struct worker_state *self)
+{
+	return self->tx_mode == KPM_TX_MODE_DEVMEM;
+}
+
 unsigned char patbuf[KPM_MAX_OP_CHUNK + PATTERN_PERIOD + 1];
 
 static struct connection *
@@ -93,6 +99,8 @@ worker_kill_conn(struct worker_state *self, struct connection *conn)
 		warn("Failed to del poll out");
 	if (self->rx_mode == KPM_RX_MODE_DEVMEM)
 		(void)devmem_release_tokens(conn->fd, &conn->devmem);
+	if (worker_devmem_tx(self))
+		devmem_teardown_conn(&conn->devmem);
 	close(conn->fd);
 	list_del(&conn->connections);
 	free(conn->rxbuf);
@@ -324,11 +332,18 @@ worker_msg_test(struct worker_state *self, struct kpm_header *hdr)
 		else
 			conn->to_recv = len;
 
-		zc = self->tx_mode == KPM_TX_MODE_SOCKET_ZEROCOPY;
+		zc = self->tx_mode == KPM_TX_MODE_SOCKET_ZEROCOPY || self->tx_mode == KPM_TX_MODE_DEVMEM;
 		if (setsockopt(conn->fd, SOL_SOCKET, SO_ZEROCOPY, &zc, sizeof(zc))) {
 			warnx("Failed to set SO_ZEROCOPY");
 			self->quit = 1;
 			return;
+		}
+
+		if (worker_devmem_tx(self)) {
+			if (devmem_setup_conn(conn->fd, &conn->devmem) < 0) {
+				self->quit = 1;
+				return;
+			}
 		}
 
 		ev.events = EPOLLIN | EPOLLOUT;
@@ -579,12 +594,19 @@ worker_handle_send(struct worker_state *self, struct connection *conn,
 	int flags = msg_zerocopy ? MSG_ZEROCOPY : 0;
 
 	while (rep--) {
-		void *src = &patbuf[conn->tot_sent % PATTERN_PERIOD];
 		size_t chunk;
+		void *src;
 		ssize_t n;
 
 		chunk = min_t(size_t, conn->write_size, conn->to_send);
-		n = send(conn->fd, src, chunk, MSG_DONTWAIT | flags);
+
+		if (self->tx_mode == KPM_TX_MODE_DEVMEM) {
+			n = devmem_sendmsg(conn->fd, &conn->devmem,
+					   conn->tot_sent % PATTERN_PERIOD, chunk);
+		} else {
+			src = &patbuf[conn->tot_sent % PATTERN_PERIOD];
+			n = send(conn->fd, src, chunk, MSG_DONTWAIT | flags);
+		}
 		if (n == 0) {
 			warnx("zero send chunk:%zd to_send:%lld to_recv:%lld",
 			      chunk, conn->to_send, conn->to_recv);
@@ -604,7 +626,7 @@ worker_handle_send(struct worker_state *self, struct connection *conn,
 
 		conn->to_send -= n;
 		conn->tot_sent += n;
-		if (msg_zerocopy) {
+		if (msg_zerocopy || self->tx_mode == KPM_TX_MODE_DEVMEM) {
 			conn->to_send_comp += 1;
 			kpm_dbg("queued send completion, total %d",
 				conn->to_send_comp);

--- a/worker.c
+++ b/worker.c
@@ -720,6 +720,20 @@ worker_handle_conn(struct worker_state *self, int fd, unsigned int events)
 		warnx("Connection has nothing to do %x", events);
 }
 
+void patbuf_init(void)
+{
+	unsigned char j;
+	int i;
+
+	/* Initialize the data buffer we send/receive, it must match
+	 * on both ends, this is how we catch data corruption (ekhm kTLS..)
+	 */
+	for (i = 0, j = 0; i < (int)ARRAY_SIZE(patbuf); i++, j++) {
+		j = j ?: 1;
+		patbuf[i] = j;
+	}
+}
+
 /* == Main loop == */
 
 void NORETURN pworker_main(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx_mode,
@@ -733,18 +747,9 @@ void NORETURN pworker_main(int fd, enum kpm_rx_mode rx_mode, enum kpm_tx_mode tx
 		.devmem = { .mem = devmem },
 	};
 	struct epoll_event ev, events[32];
-	unsigned char j;
 	int i, nfds;
 
 	list_head_init(&self.connections);
-
-	/* Initialize the data buffer we send/receive, it must match
-	 * on both ends, this is how we catch data corruption (ekhm kTLS..)
-	 */
-	for (i = 0, j = 0; i < (int)ARRAY_SIZE(patbuf); i++, j++) {
-		j = j ?: 1;
-		patbuf[i] = j;
-	}
 
 	/* Init epoll */
 	self.epollfd = epoll_create1(0);


### PR DESCRIPTION
Depends on: https://github.com/facebookexperimental/kperf/pull/13

I allowed this PR to stay dependent on #13 to avoid merge conflicts in client.c.

Tested with: `--devmem-rx --devmem-tx --devmem-rx-memory cuda --devmem-tx-memory cuda`

Output:
```
I   client.c: Connected 9:cpu 56 | 9:cpu 2
I   client.c: Connected 3:cpu 60 | 3:cpu 6
I   client.c: Connected 2:cpu 69 | 2:cpu 13
I   client.c: Connected 4:cpu 70 | 4:cpu 16
I   client.c: Connected 5:cpu 74 | 5:cpu 20
I   client.c: Connected 7:cpu 86 | 7:cpu 30
I   client.c: Connected 15:cpu 93 | 15:cpu 37
I   client.c: Connected 11:cpu 95 | 11:cpu 41
client: == Source
client:   Tx 48.146 Gbps (60188917760 bytes in 10001010 usec)
client:   Tx 97.901 Gbps (122388480000 bytes in 10001010 usec)
client:   Tx  4.606 Gbps (5757992960 bytes in 10001010 usec)
client:   Tx 95.166 Gbps (118969466880 bytes in 10001010 usec)
client:   Tx 48.320 Gbps (60406497280 bytes in 10001010 usec)
client:   Tx 49.818 Gbps (62278205440 bytes in 10001010 usec)
client:   Tx 84.831 Gbps (106049699840 bytes in 10001010 usec)
client:   Tx 48.243 Gbps (60310159360 bytes in 10001010 usec)
client:   Rx  0.000 Gbps (0 bytes in 10001010 usec)
[...snip...]
```