### PR TITLE
add cpu list affinity configuration for workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.o
 bipartite_match
 client
+cpu_affinity
 cpu_stat
 server

--- a/Makefile
+++ b/Makefile
@@ -13,12 +13,12 @@ LIBS += -L$(YNL_PATH) -lynl
 include $(wildcard *.d)
 
 all: server client units
-units: bipartite_match cpu_stat
+units: bipartite_match cpu_stat cpu_affinity
 
 server: $(CCAN_PATH)/libccan.a $(YNL_PATH)/libynl.a server.o server_session.o proto.o worker.o devmem.o cpu_stat.o tcp.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
-client: $(CCAN_PATH)/libccan.a client.o proto.o bipartite_match.o
+client: $(CCAN_PATH)/libccan.a client.o proto.o bipartite_match.o cpu_affinity.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)
 
 $(CCAN_PATH)/libccan.a:
@@ -29,16 +29,19 @@ $(YNL_PATH)/libynl.a:
 	make -C $(YNL_PATH)
 
 clean:
-	rm -rf *.o *.d *~ bipartite_match cpu_stat
+	rm -rf *.o *.d *~ bipartite_match cpu_affinity cpu_stat
 
 distclean:
-	rm -rf *.o *.d *~ bipartite_match cpu_stat server client $(CCAN_PATH)/libccan.a
+	rm -rf *.o *.d *~ bipartite_match cpu_affinity cpu_stat server client $(CCAN_PATH)/libccan.a
 
 bipartite_match: $(CCAN_PATH)/libccan.a
 	$(CC) $(CFLAGS) -DKPERF_UNITS bipartite_match.c -o bipartite_match $(CCAN_PATH)/libccan.a
 
 cpu_stat: $(CCAN_PATH)/libccan.a
 	$(CC) $(CFLAGS) -DKPERF_UNITS cpu_stat.c -o cpu_stat $(CCAN_PATH)/libccan.a
+
+cpu_affinity:
+	$(CC) $(CFLAGS) -DKPERF_UNITS cpu_affinity.c -o cpu_affinity
 
 %.o: %.c
 	$(COMPILE.c) -MMD -o $@ $<

--- a/cpu_affinity.c
+++ b/cpu_affinity.c
@@ -1,0 +1,250 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cpu_affinity.h"
+
+#define warnx(...) fprintf(stderr, ##__VA_ARGS__)
+
+#define SEGMENT_MAX_LEN 64
+#define CPU_MAX_LEN 32
+
+static void cpu_affinity_init(struct cpu_affinity *ca)
+{
+	ca->idx = 0;
+	ca->last_cpu = -1;
+	ca->cnt = 0;
+	ca->total = 0;
+}
+
+static bool cpu_affinity_list_empty(struct cpu_affinity *ca)
+{
+	return ca->cnt == 0;
+}
+
+static int cpu_affinity_add_range(struct cpu_affinity *ca, int start, int end)
+{
+	if (ca->idx >= CPU_AFFINITY_MAX)
+		return -EINVAL;
+
+	ca->start[ca->cnt] = start;
+	ca->end[ca->cnt] = end;
+	ca->cnt++;
+	ca->total += end - start + 1;
+
+	return 0;
+}
+
+int cpu_affinity_alloc_cpu(struct cpu_affinity *ca)
+{
+	int cpu;
+
+	if (ca->idx >= ca->cnt)
+		return -EINVAL;
+
+	/* if this is the first allocation, grab the first and return it */
+	if (ca->last_cpu == -1) {
+		cpu = ca->start[ca->idx];
+		goto out;
+	}
+
+	/* if next cpu can be allocated from the current start-end pair, then return it */
+	if (ca->last_cpu + 1 <= ca->end[ca->idx]) {
+		cpu = ca->last_cpu + 1;
+		goto out;
+	}
+
+	/* return the first cpu from the next pair (if it exists) */
+	if (ca->idx == ca->cnt - 1)
+		return -EINVAL;
+
+	ca->idx++;
+	cpu = ca->start[ca->idx];
+
+out:
+	ca->last_cpu = cpu;
+	return cpu;
+}
+
+static int parse_cpu_list_segment(char *segment, struct cpu_affinity *ca)
+{
+	int start, end, i;
+	char *cpu, *cpub;
+	char cpubuf[CPU_MAX_LEN + 1];
+	char *tmp;
+
+	start = -1;
+	end = -1;
+	tmp = NULL;
+
+	if (strlen(segment) >= CPU_MAX_LEN)
+		return -EINVAL;
+
+	strncpy(cpubuf, segment, CPU_MAX_LEN);
+
+	for (i = 0, cpu = strtok_r(cpubuf, "-", &cpub); cpu; cpu = strtok_r(NULL, "-", &cpub), i++) {
+		tmp = NULL;
+		errno = 0;
+		if ((i % 2) == 0)
+			start = strtol(cpu, &tmp, 10);
+		else
+			end = strtol(cpu, &tmp, 10);
+
+		if (errno == ERANGE || errno == EINVAL)
+			return -errno;
+		if (tmp == cpubuf)
+			return -EINVAL;
+
+		if (start != -1 && end != -1) {
+			/* now that we have both a start and end, add it */
+			if (cpu_affinity_add_range(ca, start, end) < 0)
+				return -EFAULT;
+
+			start = -1;
+			end = -1;
+		}
+	}
+
+	/* this segment is not a range, let's try to parse it as a single CPU number */
+	if (cpu_affinity_list_empty(ca)) {
+		tmp = NULL;
+		errno = 0;
+		start = strtol(cpubuf, &tmp, 10);
+		if (errno == ERANGE || errno == EINVAL)
+			return -errno;
+		if (tmp == cpubuf)
+			return -EINVAL;
+		end = start;
+
+		if (cpu_affinity_add_range(ca, start, end) < 0)
+			return -EFAULT;
+	}
+
+	return 0;
+}
+
+int parse_cpu_list(const char *affinity_list, struct cpu_affinity *ca)
+{
+	char *segb, *seg;
+	char segbuf[SEGMENT_MAX_LEN + 1];
+	int ret;
+
+	if (!affinity_list || !ca)
+		return -EINVAL;
+
+	cpu_affinity_init(ca);
+
+	strncpy(segbuf, affinity_list, SEGMENT_MAX_LEN);
+
+	for (seg = strtok_r(segbuf, ",", &segb); seg; seg = strtok_r(NULL, ",", &segb)) {
+		ret = parse_cpu_list_segment(seg, ca);
+		if (ret < 0)
+			return ret;
+	}
+
+	/* If it isn't comma-separated, then it might just be a single range or
+	 * cpu (e.g., "9" or "9-10")
+	 */
+	if (cpu_affinity_list_empty(ca)) {
+		ret = parse_cpu_list_segment(segbuf, ca);
+		if (ret < 0)
+			return ret;
+	}
+
+	return 0;
+}
+
+#ifdef KPERF_UNITS
+void __test(const char *str, int *expected, int n)
+{
+	struct cpu_affinity ca;
+	int cpu;
+	int i;
+
+	parse_cpu_list(str, &ca);
+
+	printf(" total=%d (%d), ", ca.total, n);
+	assert(ca.total == n);
+
+	printf("test: %s, ", str);
+
+	if (n == 0)
+		goto out;
+
+	printf("results: ");
+	for (i = 0; i < n; i++) {
+		cpu = cpu_affinity_alloc_cpu(&ca);
+		assert(cpu >= 0);
+		assert(i < n);
+		printf("%d (%d), ", cpu, expected[i]);
+		assert(cpu == expected[i]);
+	}
+
+out:
+	printf("ok\n");
+}
+
+#define test(_str, _exp, _n) ({ printf("%s:", __func__); __test((_str), (_exp), (_n)); })
+
+void test_one_num(void)
+{
+	char *str = "9";
+	int expected[] = { 9 };
+
+	test(str, expected, 1);
+}
+
+void test_one_seg(void)
+{
+	char *str = "5-7";
+	int expected[] = { 5, 6, 7 };
+
+	test(str, expected, 3);
+}
+
+void test_two_segs(void)
+{
+	char *str = "1-4,20-21";
+	int expected[] = { 1, 2, 3, 4, 20, 21 };
+
+	test(str, expected, 6);
+}
+
+void test_nan(void)
+{
+	char *str = "foobar";
+	int expected[] = {};
+
+	test(str, expected, 0);
+}
+
+void test_inval(void)
+{
+	char *str = "1-A";
+	int expected[] = {};
+
+	test(str, expected, 0);
+}
+
+void test_range(void)
+{
+	int expected[] = {};
+
+	test("18446744073709551616", expected, 0);
+}
+
+int main(void)
+{
+	test_one_num();
+	test_one_seg();
+	test_two_segs();
+	test_nan();
+	test_inval();
+	test_range();
+
+	return 0;
+}
+#endif

--- a/cpu_affinity.h
+++ b/cpu_affinity.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright Meta Platforms, Inc. and affiliates */
+
+#ifndef CPU_AFFINITY_H
+#define CPU_AFFINITY_H
+
+#define CPU_AFFINITY_MAX 32
+
+struct cpu_affinity {
+	/* the start CPUs of the start-end pairs */
+	int start[CPU_AFFINITY_MAX];
+	/* the end CPUs of the start-end pairs */
+	int end[CPU_AFFINITY_MAX];
+	/* the total count of pairs added */
+	int cnt;
+	/* the idx into the current pair */
+	int idx;
+	/* the last cpu allocated */
+	int last_cpu;
+	/* total number of cpus */
+	int total;
+};
+
+int parse_cpu_list(const char *affinity_list, struct cpu_affinity *ca);
+int cpu_affinity_alloc_cpu(struct cpu_affinity *ca);
+
+#endif /* CPU_AFFINITY_H */


### PR DESCRIPTION
Add the ability to configure worker cpu affinity using cpu lists. This commit adds the following arguments to the client:

	--cpu-src-wrk-affinity <cpu-list>
	--cpu-dst-wrk-affinity <cpu-list>

The `<cpu-list>` argument takes the following format:
	`<cpu-or-range>[,<cpu-or-range>, ...]`
Where `cpu-or-range` can be either:
- `cpu`: An integer representing a single CPU number.
- `range`: A range in the format `<cpu>-<cpu>`, representing an inclusive range from the first to second cpu

Usually kperf avoids CPU contention via bipartite match, but the client is only aware of the bipartite graph of a single pair of servers. If the user wants to test multiple NICs they must bind one server to each NIC and invoke multiple clients (one client per server pair).  The bipartite graphs are distinct and may result in duplicates, and consequently CPU contention.

If there are more connections (and therefore more workers) than configured CPUs, then affinity allocator will fail:

./client -n 2 --cpu-src-wrk-affinity 1
I   client.c: Connected 1:cpu 131 | 1:cpu 74
I   client.c: Connected 4189:cpu 134 | 4189:cpu 36
client: failed to alloc cpu from affinity list 1, err=-22

Unit tests may be ran as follows:
	make units
	./cpu_affinity
	test_one_num: total=1 (1), test: 9, results: 9 (9), ok
	test_one_seg: total=3 (3), test: 5-7, results: 5 (5), 6 (6), 7 (7), ok
	test_two_segs: total=6 (6), test: 1-4,20-21, results: 1 (1), 2 (2), 3
	(3), 4 (4), 20 (20), 21 (21), ok
	test_nan: total=0 (0), test: foobar, ok
	test_inval: total=0 (0), test: 1-A, ok
	test_range: total=0 (0), test: 18446744073709551616, ok
	
	
Changes in v2:
- changed default string to NULL ptr and removed strcmp()
- combined some of the conditionals checking for mutual exclusion of arguments