### PR TITLE
epoll: add TCP zerocopy receive support

### DIFF
--- a/client.c
+++ b/client.c
@@ -765,15 +765,11 @@ int main(int argc, char *argv[])
 	if (opt.devmem_tx && opt.iou_src)
 		errx(1, "io_uring does not support --devmem-tx yet");
 
-	/* epoll doesn't support zero copy receive yet */
-	if (opt.zerocopy_rx && !opt.iou_dst)
-		errx(1, "epoll does not support --zerocopy-rx yet");
-
 	if (opt.msg_trunc && opt.validate)
 		errx(1, "--msg-trunc and --validate yes are mutually exclusive");
 
-	if (opt.msg_trunc && (opt.devmem_rx || opt.iou_dst))
-		errx(1, "--msg-trunc and (--devmem-rx or --iou-dst) are mutually exclusive");
+	if (opt.msg_trunc && (opt.devmem_rx || opt.zerocopy_rx))
+		errx(1, "--msg-trunc and (--devmem-rx or --zerocopy-rx) are mutually exclusive");
 
 	if (opt.msg_trunc)
 		rx_mode = KPM_RX_MODE_SOCKET_TRUNC;

--- a/worker.h
+++ b/worker.h
@@ -45,6 +45,12 @@ struct worker_connection {
 	__u64 tot_sent;
 	__u64 tot_recv;
 	unsigned char *rxbuf;
+
+	/* zero copy receive */
+	size_t rsize;
+	void *raddr;
+	void *addr;
+
 	struct connection_devmem devmem;
 	struct kpm_test_spec *spec;
 	struct tcp_info init_info;


### PR DESCRIPTION
Add support for --zercopy-rx with epoll IO engine.