### PR TITLE
server: fix unpropagated worker_opts

### DIFF
--- a/worker.h
+++ b/worker.h
@@ -16,8 +16,6 @@
 struct worker_state {
 	int main_sock;
 	struct worker_opts opts;
-	enum kpm_rx_mode rx_mode;
-	enum kpm_tx_mode tx_mode;
 	int epollfd;
 	unsigned int id;
 	int quit;
@@ -28,7 +26,6 @@ struct worker_state {
 	struct timemono prev_loop;
 	unsigned int test_len_msec;
 	struct list_head connections;
-	bool validate;
 	const struct io_ops *ops;
 	void *io_state;
 };


### PR DESCRIPTION
worker_state.{rx_mode,tx_mode,validate} are no longer updated, so reference the mode and validate fields of worker_opts instead of worker_state. Remove these fields from worker_state. This fixes bugs caused by using these fields uninitialized.

Fixes: 3b4a31b4b8f2 ("worker: refactor worker_main_args to worker_opts")