### PR TITLE
Makefile server_session: fix existing compile error, add compile flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ ifdef USE_CUDA
     CFLAGS += -I/usr/local/cuda/include/ -DUSE_CUDA
 endif
 
+ifdef USE_DMA_BUF_PCIE_MAP
+    CFLAGS += -DUSE_DMA_BUF_PCIE_MAP
+endif
+
 include $(wildcard *.d)
 
 all: server client units

--- a/devmem.c
+++ b/devmem.c
@@ -33,8 +33,7 @@
 #ifdef USE_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
-
-#ifdef CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE
+#ifdef USE_DMA_BUF_PCIE_MAP
 #define CUDA_FLAGS CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE
 #else
 #define CUDA_FLAGS 0

--- a/server_session.c
+++ b/server_session.c
@@ -148,7 +148,7 @@ static int psp_exchange_keys(struct session_state *self, int cfd)
 		err(2, "YNL PSP Rx assoc: %s\n", self->psp->err.msg);
 
 	ret = kpm_send_psp_params(cfd, rsp->rx_key.spi, rsp->rx_key.key,
-				  rsp->rx_key._len.key);
+				  rsp->rx_key._present.key_len);
 	if (ret < 0)
 		err(3, "Can't send PSP params: %d\n", ret);
 	psp_rx_assoc_rsp_free(rsp);


### PR DESCRIPTION
Summary:
1. current upstream has a compile error due to typo in previous commit. fix it to make it compile.
2. add a compile flag to enable CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE which is needed to map via Data Direct Interface

Test Plan:
make sure kperf compile: make USE_CUDA=1 USE_DMA_BUF_PCIE_MAP=1

Tags: