### PR TITLE
Fix DNS breakage for --src <hostname>

### DIFF
--- a/client.c
+++ b/client.c
@@ -691,7 +691,7 @@ dump_result_machine(struct kpm_test_results *result,
 /* copied from devmem.c */
 static void inet_to_inet6(struct sockaddr *addr, struct sockaddr_in6 *out)
 {
-	out->sin6_addr.s6_addr32[3] = ((struct sockaddr_in6 *)addr)->sin6_addr.s6_addr32[0];
+	out->sin6_addr.s6_addr32[3] = ((struct sockaddr_in *)addr)->sin_addr.s_addr;
 	out->sin6_addr.s6_addr32[0] = 0;
 	out->sin6_addr.s6_addr32[1] = 0;
 	out->sin6_addr.s6_addr16[4] = 0;

--- a/client.c
+++ b/client.c
@@ -701,23 +701,35 @@ static void inet_to_inet6(struct sockaddr *addr, struct sockaddr_in6 *out)
 
 int inet_sockaddr(const char *str, struct sockaddr_in6 *out)
 {
-	struct sockaddr_in *sa4;
-	struct sockaddr_in6 tmp;
+	struct addrinfo *res, *ai;
+	int err;
 
-	out->sin6_family = AF_INET6;
-	if (inet_pton(AF_INET6, str, &(out->sin6_addr)) == 1) {
+	res = net_client_lookup(str, NULL, AF_UNSPEC, SOCK_STREAM);
+	if (!res) {
+		warnx("Failed to resolve %s", str);
+		return -1;
+	}
+
+	memset(out, 0, sizeof(*out));
+	err = -1;
+	for (ai = res; ai; ai = ai->ai_next) {
+		if (ai->ai_family == AF_INET6)
+			memcpy(out, ai->ai_addr, sizeof(*out));
+		else if (ai->ai_family == AF_INET)
+			inet_to_inet6(ai->ai_addr, out);
+		else
+			continue;
+
 		out->sin6_family = AF_INET6;
-		return 0;
+		out->sin6_port = 0;
+		err = 0;
+		break;
 	}
+	if (err)
+		warnx("No IP address found for %s", str);
 
-	sa4 = (struct sockaddr_in *)&tmp;
-	if (inet_pton(AF_INET, str, &(sa4->sin_addr)) == 1) {
-		sa4->sin_family = AF_INET;
-		inet_to_inet6((void *)sa4, out);
-		return 0;
-	}
-
-	return -1;
+	freeaddrinfo(res);
+	return err;
 }
 
 int main(int argc, char *argv[])


### PR DESCRIPTION
These patches fix two bugs: 1) --src <hostname> fails on hostnames and 2) ipv4 + --devmem-tx produces garbage address.

See commit messages for more details.